### PR TITLE
external module 'React' should be 'react'

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,7 @@ if (PRODUCTION) {
 
 module.exports = {
   entry:  `${__dirname}/src/components/JsxParser.js`,
-  externals: { react: 'React' },
+  externals: { react: 'react' },
   module: {
     loaders: [{
       test:    /\.js$/,


### PR DESCRIPTION
On adding the library with yarn and importing into the project the following error was raised:
```
ERROR in ./~/react-jsx-parser/lib/react-jsx-parser.min.js
Module not found: Error: [CaseSensitivePathsPlugin] `/node_modules/React/react.js` does not match the corresponding path on disk `react`.
 @ ./~/react-jsx-parser/lib/react-jsx-parser.min.js 1:82-98
```
This change allows react to be imported correctly. Build will have to be updated and pushed to npm