### PR TITLE
Components prop should be map-based, to avoid incompatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ A React component which can parse JSX and output rendered React Components.
 
 ## Basic Usage - Injecting JSX as a String
 ```javascript
-import * as React from 'react'
+import React, { Component } from 'react'
 import JsxParser from 'react-jsx-parser'
 
-class InjectableComponent extends React.Component {
+class InjectableComponent extends Component {
   // ... inner workings of InjectableComponent
 }
 
-class MyComponent extends React.Component {
+class MyComponent extends Component {
   render() {
     /* Pull out parent props which shouldn't be bound,
        then pass the rest as `bindings` to all children */
@@ -24,7 +24,7 @@ class MyComponent extends React.Component {
     return (
       <JsxParser
         bindings={bindings}
-        components={[InjectableComponent]}
+        components={{ InjectableComponent }}
         jsx={'\
           <h1>Header</h1>\
           <InjectableComponent />\
@@ -40,8 +40,7 @@ Because `InjectableComponent` is passed into the `JsxParser.props.components` pr
 ## Advanced Usage - Injecting Dynamic JSX
 ```javascript
 // Import desired set of components
-import ComponentA from 'somePackage/ComponentA'
-import ComponentB from 'somePackage/ComponentB'
+import { ComponentA, ComponentB } from 'somePackage/Components'
 import ComponentC from 'somePackage/ComponentC'
 import ComponentD from 'somePackage/ComponentD'
 ...
@@ -51,7 +50,7 @@ const dynamicHtml = loadRemoteData()
 // Within your component's render method, bind these components and the fragment as props
 <JsxParser
   bindings={bindings}
-  components={[ComponentA, ComponentB, ComponentC, ComponentD]}
+  components={{ ComponentA, ComponentB, ComponentC, ComponentD }}
   jsx={dynamicHtml}
 />
 ```
@@ -72,12 +71,9 @@ JsxParser.defaultProps = {
   // by default, removes all <script> tags
   blacklistedTags:  ['script'],
 
-  // Components must extend React.Component or React.PureComponent
-  components: [],
+  // Components must extend React.Component, React.PureComponent, or be a Function
+  components: {},
 
   jsx: '',
 }
 ```
-
-## Known Limitations
-* Custom elements must have a closing tag.

--- a/circle.yml
+++ b/circle.yml
@@ -18,8 +18,6 @@ dependencies:
 machine:
   environment:
     PATH: "${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
-  node:
-    version: v7.10.0
 
 ## Customize test commands
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -18,6 +18,8 @@ dependencies:
 machine:
   environment:
     PATH: "${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
+  node:
+    version: v7.10.0
 
 ## Customize test commands
 test:

--- a/lib/react-jsx-parser.min.js
+++ b/lib/react-jsx-parser.min.js
@@ -6,43 +6,37 @@ return t.d(r,"a",r),r},t.o=function(e,t){return Object.prototype.hasOwnProperty.
 function n(e){return e.replace(/([A-Z])([A-Z])/g,"$1 $2").replace(/([a-z])([A-Z])/g,"$1 $2").replace(/[^a-zA-Z\u00C0-\u00ff]/g," ").toLowerCase().split(" ").filter(function(e){return e}).map(function(e,t){return t>0?e[0].toUpperCase()+e.slice(1):e}).join("")}Object.defineProperty(t,"__esModule",{value:!0}),t.default=n},function(e,t,r){"use strict"
 function n(e){return e&&e.__esModule?e:{default:e}}function o(e,t,r){return t in e?Object.defineProperty(e,t,{value:r,enumerable:!0,configurable:!0,writable:!0}):e[t]=r,e}function a(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}function i(e,t){if(!e)throw new ReferenceError("this hasn't been initialised - super() hasn't been called")
 return!t||"object"!=typeof t&&"function"!=typeof t?e:t}function u(e,t){if("function"!=typeof t&&null!==t)throw new TypeError("Super expression must either be null or a function, not "+typeof t)
-e.prototype=Object.create(t&&t.prototype,{constructor:{value:e,enumerable:!1,writable:!0,configurable:!0}}),t&&(Object.setPrototypeOf?Object.setPrototypeOf(e,t):e.__proto__=t)}function c(e){return e&&(e.prototype instanceof d.default.Component||e.prototype instanceof d.default.PureComponent||"function"==typeof e)}Object.defineProperty(t,"__esModule",{value:!0})
+e.prototype=Object.create(t&&t.prototype,{constructor:{value:e,enumerable:!1,writable:!0,configurable:!0}}),t&&(Object.setPrototypeOf?Object.setPrototypeOf(e,t):e.__proto__=t)}Object.defineProperty(t,"__esModule",{value:!0})
 var s=Object.assign||function(e){for(var t=1;t<arguments.length;t++){var r=arguments[t]
-for(var n in r)Object.prototype.hasOwnProperty.call(r,n)&&(e[n]=r[n])}return e},f=function(){function e(e,t){var r=[],n=!0,o=!1,a=void 0
-try{for(var i,u=e[Symbol.iterator]();!(n=(i=u.next()).done)&&(r.push(i.value),!t||r.length!==t);n=!0);}catch(e){o=!0,a=e}finally{try{!n&&u.return&&u.return()}finally{if(o)throw a}}return r}return function(t,r){if(Array.isArray(t))return t
-if(Symbol.iterator in Object(t))return e(t,r)
-throw new TypeError("Invalid attempt to destructure non-iterable instance")}}(),l=function(){function e(e,t){for(var r=0;r<t.length;r++){var n=t[r]
-n.enumerable=n.enumerable||!1,n.configurable=!0,"value"in n&&(n.writable=!0),Object.defineProperty(e,n.key,n)}}return function(t,r,n){return r&&e(t.prototype,r),n&&e(t,n),t}}(),p=r(2),d=n(p),y=r(0),m=n(y),h=r(3),b=n(h),v=r(4),g=n(v),O=r(5),E=n(O),T=r(6),_=n(T),x=r(7),w=new DOMParser,N=function(e){var t=Array.from(e.documentElement.childNodes)
+for(var n in r)Object.prototype.hasOwnProperty.call(r,n)&&(e[n]=r[n])}return e},c=function(){function e(e,t){for(var r=0;r<t.length;r++){var n=t[r]
+n.enumerable=n.enumerable||!1,n.configurable=!0,"value"in n&&(n.writable=!0),Object.defineProperty(e,n.key,n)}}return function(t,r,n){return r&&e(t.prototype,r),n&&e(t,n),t}}(),f=r(2),l=n(f),p=r(0),d=n(p),y=r(3),m=n(y),h=r(4),b=n(h),v=r(5),g=n(v),O=r(6),E=n(O),T=r(7),_=new DOMParser,x=function(e){var t=Array.from(e.documentElement.childNodes)
 console.warn("Unable to parse jsx. Found "+t.length+" error(s):")
 var r=function e(t,r){t.childNodes.length&&Array.from(t.childNodes).forEach(function(t){return e(t,r.concat(" "))}),console.warn(r+"==> "+t.nodeValue)}
-t.forEach(function(e){return r(e," ")})},j=function(e){function t(e){a(this,t)
+t.forEach(function(e){return r(e," ")})},N=function(e){function t(e){a(this,t)
 var r=i(this,(t.__proto__||Object.getPrototypeOf(t)).call(this,e))
-return r.parseJSX.bind(r),r.parseNode.bind(r),r.ParsedChildren=r.parseJSX(e.jsx||""),r}return u(t,e),l(t,[{key:"componentWillReceiveProps",value:function(e){this.ParsedChildren=this.parseJSX(e.jsx||"")}},{key:"parseJSX",value:function(e){if(!e||"string"!=typeof e)return[]
-var t=this.props.blacklistedTags.reduce(function(e,t){return e.replace(new RegExp("(</?)"+t,"ig"),"$1REMOVE")},e).trim(),r=(0,g.default)(t)?t:"<!DOCTYPE html>\n<html><body>"+t+"</body></html>",n=w.parseFromString(r,"application/xhtml+xml")
+return r.parseJSX.bind(r),r.parseNode.bind(r),r.ParsedChildren=r.parseJSX(e.jsx||""),r}return u(t,e),c(t,[{key:"componentWillReceiveProps",value:function(e){this.ParsedChildren=this.parseJSX(e.jsx||"")}},{key:"parseJSX",value:function(e){if(!e||"string"!=typeof e)return[]
+var t=this.props.blacklistedTags.reduce(function(e,t){return e.replace(new RegExp("(</?)"+t,"ig"),"$1REMOVE")},e).trim(),r=(0,b.default)(t)?t:"<!DOCTYPE html>\n<html><body>"+t+"</body></html>",n=_.parseFromString(r,"application/xhtml+xml")
 if(!n)return[]
 Array.from(n.getElementsByTagName("REMOVE")).forEach(function(e){return e.parentNode.removeChild(e)})
-var a=n.getElementsByTagName("body")[0]
-if(!a||"parseerror"===a.nodeName.toLowerCase())return this.props.showWarnings&&N(n),[]
-var i=Object.entries(this.props.components).reduce(function(e,t){var r=f(t,2),n=r[0],a=r[1]
-return c(a)?s({},e,o({},n,a)):e},{})
-return this.parseNode(a.childNodes||[],i)}},{key:"parseNode",value:function(e){var t=this,r=arguments.length>1&&void 0!==arguments[1]?arguments[1]:{},n=arguments[2]
-if(e instanceof NodeList||Array.isArray(e))return Array.from(e).map(function(e,n){return t.parseNode(e,r,n)}).filter(function(e){return e})
-if(e.nodeType===_.default.TEXT)return("textContent"in e?e.textContent:e.nodeValue||"").replace(/[\r\n\t\f\v]/g,"").replace(/\s{2,}/g," ")
-if(e.nodeType===_.default.ELEMENT){var o=void 0
-return(0,x.canHaveChildren)(e.nodeName)&&(o=this.parseNode(e.childNodes,r),(0,x.canHaveWhitespace)(e.nodeName)||(o=o.filter(function(e){return"string"!=typeof e||!e.match(/^\s*$/)}))),d.default.createElement(r[e.nodeName]||e.nodeName,s({},this.props.bindings||{},this.parseAttrs(e.attributes,n)),o)}return this.props.showWarnings&&console.warn("JsxParser encountered a(n) "+_.default[e.nodeType]+" node, and discarded it."),null}},{key:"parseAttrs",value:function(e,t){if(!e||!e.length)return{key:t}
+var o=n.getElementsByTagName("body")[0]
+return o&&"parseerror"!==o.nodeName.toLowerCase()?this.parseNode(o.childNodes||[],this.props.components):(this.props.showWarnings&&x(n),[])}},{key:"parseNode",value:function(e){var t=this,r=arguments.length>1&&void 0!==arguments[1]?arguments[1]:{},n=arguments[2]
+if(e instanceof NodeList||Array.isArray(e))return Array.from(e).map(function(e,n){return t.parseNode(e,r,n)}).filter(Boolean)
+if(e.nodeType===E.default.TEXT)return("textContent"in e?e.textContent:e.nodeValue||"").replace(/[\r\n\t\f\v]/g,"").replace(/\s{2,}/g," ")
+if(e.nodeType===E.default.ELEMENT){var o=void 0
+return(0,T.canHaveChildren)(e.nodeName)&&(o=this.parseNode(e.childNodes,r),(0,T.canHaveWhitespace)(e.nodeName)||(o=o.filter(function(e){return"string"!=typeof e||!e.match(/^\s*$/)}))),l.default.createElement(r[e.nodeName]||e.nodeName,s({},this.props.bindings||{},this.parseAttrs(e.attributes,n)),o)}return this.props.showWarnings&&console.warn("JsxParser encountered a(n) "+E.default[e.nodeType]+" node, and discarded it."),null}},{key:"parseAttrs",value:function(e,t){if(!e||!e.length)return{key:t}
 var r=this.props.blacklistedAttrs
 return Array.from(e).filter(function(e){return!r.map(function(t){return e.name.match(new RegExp(t,"gi"))}).filter(function(e){return null!==e}).length}).reduce(function(e,t){var r=t.name,n=t.value
-return""===n&&(n=!0),r.match(/^on/i)?n=new Function(n):"style"===r&&(n=(0,b.default)(n)),r=E.default[r.toLowerCase()]||(0,m.default)(r),s({},e,o({},r,n))},{key:t})}},{key:"render",value:function(){return d.default.createElement("div",{className:"jsx-parser"},this.ParsedChildren)}}]),t}(p.Component)
-t.default=j,j.defaultProps={bindings:{},blacklistedAttrs:["on[a-z]*"],blacklistedTags:["script"],components:[],jsx:"",showWarnings:!1}
+return""===n&&(n=!0),r.match(/^on/i)?n=new Function(n):"style"===r&&(n=(0,m.default)(n)),r=g.default[r.toLowerCase()]||(0,d.default)(r),s({},e,o({},r,n))},{key:t})}},{key:"render",value:function(){return l.default.createElement("div",{className:"jsx-parser"},this.ParsedChildren)}}]),t}(f.Component)
+t.default=N,N.defaultProps={bindings:{},blacklistedAttrs:["on[a-z]*"],blacklistedTags:["script"],components:[],jsx:"",showWarnings:!1}
 r(8)},function(t,r){t.exports=e},function(e,t,r){"use strict"
 function n(e,t,r){return t in e?Object.defineProperty(e,t,{value:r,enumerable:!0,configurable:!0,writable:!0}):e[t]=r,e}function o(e){switch(void 0===e?"undefined":i(e)){case"string":return e.split(";").filter(function(e){return e}).reduce(function(e,t){var r=t.slice(0,t.indexOf(":")).trim(),o=t.slice(t.indexOf(":")+1).trim()
-return a({},e,n({},(0,c.default)(r),o))},{})
+return a({},e,n({},(0,s.default)(r),o))},{})
 case"object":return e
 default:return}}Object.defineProperty(t,"__esModule",{value:!0})
 var a=Object.assign||function(e){for(var t=1;t<arguments.length;t++){var r=arguments[t]
 for(var n in r)Object.prototype.hasOwnProperty.call(r,n)&&(e[n]=r[n])}return e},i="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e}
 t.default=o
-var u=r(0),c=function(e){return e&&e.__esModule?e:{default:e}}(u)},function(e,t,r){"use strict"
+var u=r(0),s=function(e){return e&&e.__esModule?e:{default:e}}(u)},function(e,t,r){"use strict"
 function n(e){return/<(\/?|!?)DOCTYPE html>/.test(e)&&/<(\/?|!?)html>/.test(e)&&/<(\/?|!?)head>/.test(e)&&/<(\/?|!?)body>/.test(e)}Object.defineProperty(t,"__esModule",{value:!0}),t.default=n},function(e,t,r){"use strict"
 Object.defineProperty(t,"__esModule",{value:!0}),t.default={class:"className",for:"htmlFor",maxlength:"maxLength",colspan:"colSpan",rowspan:"rowSpan"}},function(e,t,r){"use strict"
 Object.defineProperty(t,"__esModule",{value:!0}),t.default={ELEMENT:1,TEXT:3,PROCESSING_INSTRUCTION:7,COMMENT:8,DOCUMENT:9,DOCUMENT_TYPE:10,DOCUMENT_FRAGMENT:11,1:"Element",3:"Text",7:"Processing Instruction",8:"Comment",9:"Document",10:"Document Type",11:"Document Fragment",ATTRIBUTE:2,CDATA:4,XML_ENTITY_REFERENCE:5,XML_ENTITY:6,XML_NOTATION:12,2:"Attribute (Deprecated)",4:"CData (Deprecated)",5:"XML Entity Reference (Deprecated)",6:"XML Entity (Deprecated)",12:"XML Notation (Deprecated)"}},function(e,t,r){"use strict"
@@ -55,9 +49,9 @@ var r={array:e,bool:e,func:e,number:e,object:e,string:e,symbol:e,any:e,arrayOf:t
 return r.checkPropTypes=n,r.PropTypes=r,r}},function(e,t,r){"use strict"
 function n(e){return function(){return e}}var o=function(){}
 o.thatReturns=n,o.thatReturnsFalse=n(!1),o.thatReturnsTrue=n(!0),o.thatReturnsNull=n(null),o.thatReturnsThis=function(){return this},o.thatReturnsArgument=function(e){return e},e.exports=o},function(e,t,r){"use strict"
-function n(e,t,r,n,a,i,u,c){if(o(t),!e){var s
-if(void 0===t)s=new Error("Minified exception occurred; use the non-minified dev environment for the full error message and additional helpful warnings.")
-else{var f=[r,n,a,i,u,c],l=0
-s=new Error(t.replace(/%s/g,function(){return f[l++]})),s.name="Invariant Violation"}throw s.framesToPop=1,s}}var o=function(e){}
+function n(e,t,r,n,a,i,u,s){if(o(t),!e){var c
+if(void 0===t)c=new Error("Minified exception occurred; use the non-minified dev environment for the full error message and additional helpful warnings.")
+else{var f=[r,n,a,i,u,s],l=0
+c=new Error(t.replace(/%s/g,function(){return f[l++]})),c.name="Invariant Violation"}throw c.framesToPop=1,c}}var o=function(e){}
 e.exports=n},function(e,t,r){"use strict"
 e.exports="SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED"}])})

--- a/lib/react-jsx-parser.min.js
+++ b/lib/react-jsx-parser.min.js
@@ -6,30 +6,34 @@ return t.d(r,"a",r),r},t.o=function(e,t){return Object.prototype.hasOwnProperty.
 function n(e){return e.replace(/([A-Z])([A-Z])/g,"$1 $2").replace(/([a-z])([A-Z])/g,"$1 $2").replace(/[^a-zA-Z\u00C0-\u00ff]/g," ").toLowerCase().split(" ").filter(function(e){return e}).map(function(e,t){return t>0?e[0].toUpperCase()+e.slice(1):e}).join("")}Object.defineProperty(t,"__esModule",{value:!0}),t.default=n},function(e,t,r){"use strict"
 function n(e){return e&&e.__esModule?e:{default:e}}function o(e,t,r){return t in e?Object.defineProperty(e,t,{value:r,enumerable:!0,configurable:!0,writable:!0}):e[t]=r,e}function a(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}function i(e,t){if(!e)throw new ReferenceError("this hasn't been initialised - super() hasn't been called")
 return!t||"object"!=typeof t&&"function"!=typeof t?e:t}function u(e,t){if("function"!=typeof t&&null!==t)throw new TypeError("Super expression must either be null or a function, not "+typeof t)
-e.prototype=Object.create(t&&t.prototype,{constructor:{value:e,enumerable:!1,writable:!0,configurable:!0}}),t&&(Object.setPrototypeOf?Object.setPrototypeOf(e,t):e.__proto__=t)}Object.defineProperty(t,"__esModule",{value:!0})
-var c=Object.assign||function(e){for(var t=1;t<arguments.length;t++){var r=arguments[t]
-for(var n in r)Object.prototype.hasOwnProperty.call(r,n)&&(e[n]=r[n])}return e},s=function(){function e(e,t){for(var r=0;r<t.length;r++){var n=t[r]
-n.enumerable=n.enumerable||!1,n.configurable=!0,"value"in n&&(n.writable=!0),Object.defineProperty(e,n.key,n)}}return function(t,r,n){return r&&e(t.prototype,r),n&&e(t,n),t}}(),f=r(2),l=n(f),p=r(0),d=n(p),y=r(3),m=n(y),h=r(4),b=n(h),v=r(5),g=n(v),O=r(6),E=n(O),T=r(7),_=new DOMParser,x=function(e){var t=Array.from(e.documentElement.childNodes)
+e.prototype=Object.create(t&&t.prototype,{constructor:{value:e,enumerable:!1,writable:!0,configurable:!0}}),t&&(Object.setPrototypeOf?Object.setPrototypeOf(e,t):e.__proto__=t)}function c(e){return e&&(e.prototype instanceof d.default.Component||e.prototype instanceof d.default.PureComponent||"function"==typeof e)}Object.defineProperty(t,"__esModule",{value:!0})
+var s=Object.assign||function(e){for(var t=1;t<arguments.length;t++){var r=arguments[t]
+for(var n in r)Object.prototype.hasOwnProperty.call(r,n)&&(e[n]=r[n])}return e},f=function(){function e(e,t){var r=[],n=!0,o=!1,a=void 0
+try{for(var i,u=e[Symbol.iterator]();!(n=(i=u.next()).done)&&(r.push(i.value),!t||r.length!==t);n=!0);}catch(e){o=!0,a=e}finally{try{!n&&u.return&&u.return()}finally{if(o)throw a}}return r}return function(t,r){if(Array.isArray(t))return t
+if(Symbol.iterator in Object(t))return e(t,r)
+throw new TypeError("Invalid attempt to destructure non-iterable instance")}}(),l=function(){function e(e,t){for(var r=0;r<t.length;r++){var n=t[r]
+n.enumerable=n.enumerable||!1,n.configurable=!0,"value"in n&&(n.writable=!0),Object.defineProperty(e,n.key,n)}}return function(t,r,n){return r&&e(t.prototype,r),n&&e(t,n),t}}(),p=r(2),d=n(p),y=r(0),m=n(y),h=r(3),b=n(h),v=r(4),g=n(v),O=r(5),E=n(O),T=r(6),_=n(T),x=r(7),w=new DOMParser,N=function(e){var t=Array.from(e.documentElement.childNodes)
 console.warn("Unable to parse jsx. Found "+t.length+" error(s):")
 var r=function e(t,r){t.childNodes.length&&Array.from(t.childNodes).forEach(function(t){return e(t,r.concat(" "))}),console.warn(r+"==> "+t.nodeValue)}
-t.forEach(function(e){return r(e," ")})},N=function(e){function t(e){a(this,t)
+t.forEach(function(e){return r(e," ")})},j=function(e){function t(e){a(this,t)
 var r=i(this,(t.__proto__||Object.getPrototypeOf(t)).call(this,e))
-return r.parseJSX.bind(r),r.parseNode.bind(r),r.ParsedChildren=r.parseJSX(e.jsx||""),r}return u(t,e),s(t,[{key:"componentWillReceiveProps",value:function(e){this.ParsedChildren=this.parseJSX(e.jsx||"")}},{key:"parseJSX",value:function(e){if(!e||"string"!=typeof e)return[]
-var t=this.props.blacklistedTags.reduce(function(e,t){return e.replace(new RegExp("(</?)"+t,"ig"),"$1REMOVE")},e).trim(),r=(0,b.default)(t)?t:"<!DOCTYPE html>\n<html><body>"+t+"</body></html>",n=_.parseFromString(r,"application/xhtml+xml")
+return r.parseJSX.bind(r),r.parseNode.bind(r),r.ParsedChildren=r.parseJSX(e.jsx||""),r}return u(t,e),l(t,[{key:"componentWillReceiveProps",value:function(e){this.ParsedChildren=this.parseJSX(e.jsx||"")}},{key:"parseJSX",value:function(e){if(!e||"string"!=typeof e)return[]
+var t=this.props.blacklistedTags.reduce(function(e,t){return e.replace(new RegExp("(</?)"+t,"ig"),"$1REMOVE")},e).trim(),r=(0,g.default)(t)?t:"<!DOCTYPE html>\n<html><body>"+t+"</body></html>",n=w.parseFromString(r,"application/xhtml+xml")
 if(!n)return[]
 Array.from(n.getElementsByTagName("REMOVE")).forEach(function(e){return e.parentNode.removeChild(e)})
 var a=n.getElementsByTagName("body")[0]
-if(!a||"parseerror"===a.nodeName.toLowerCase())return this.props.showWarnings&&x(n),[]
-var i=this.props.components.reduce(function(e,t){return c({},e,o({},t.prototype.constructor.name,t))},{})
+if(!a||"parseerror"===a.nodeName.toLowerCase())return this.props.showWarnings&&N(n),[]
+var i=Object.entries(this.props.components).reduce(function(e,t){var r=f(t,2),n=r[0],a=r[1]
+return c(a)?s({},e,o({},n,a)):e},{})
 return this.parseNode(a.childNodes||[],i)}},{key:"parseNode",value:function(e){var t=this,r=arguments.length>1&&void 0!==arguments[1]?arguments[1]:{},n=arguments[2]
 if(e instanceof NodeList||Array.isArray(e))return Array.from(e).map(function(e,n){return t.parseNode(e,r,n)}).filter(function(e){return e})
-if(e.nodeType===E.default.TEXT)return("textContent"in e?e.textContent:e.nodeValue||"").replace(/[\r\n\t\f\v]/g,"").replace(/\s{2,}/g," ")
-if(e.nodeType===E.default.ELEMENT){var o=void 0
-return(0,T.canHaveChildren)(e.nodeName)&&(o=this.parseNode(e.childNodes,r),(0,T.canHaveWhitespace)(e.nodeName)||(o=o.filter(function(e){return"string"!=typeof e||!e.match(/^\s*$/)}))),l.default.createElement(r[e.nodeName]||e.nodeName,c({},this.props.bindings||{},this.parseAttrs(e.attributes,n)),o)}return this.props.showWarnings&&console.warn("JsxParser encountered a(n) "+E.default[e.nodeType]+" node, and discarded it."),null}},{key:"parseAttrs",value:function(e,t){if(!e||!e.length)return{key:t}
+if(e.nodeType===_.default.TEXT)return("textContent"in e?e.textContent:e.nodeValue||"").replace(/[\r\n\t\f\v]/g,"").replace(/\s{2,}/g," ")
+if(e.nodeType===_.default.ELEMENT){var o=void 0
+return(0,x.canHaveChildren)(e.nodeName)&&(o=this.parseNode(e.childNodes,r),(0,x.canHaveWhitespace)(e.nodeName)||(o=o.filter(function(e){return"string"!=typeof e||!e.match(/^\s*$/)}))),d.default.createElement(r[e.nodeName]||e.nodeName,s({},this.props.bindings||{},this.parseAttrs(e.attributes,n)),o)}return this.props.showWarnings&&console.warn("JsxParser encountered a(n) "+_.default[e.nodeType]+" node, and discarded it."),null}},{key:"parseAttrs",value:function(e,t){if(!e||!e.length)return{key:t}
 var r=this.props.blacklistedAttrs
 return Array.from(e).filter(function(e){return!r.map(function(t){return e.name.match(new RegExp(t,"gi"))}).filter(function(e){return null!==e}).length}).reduce(function(e,t){var r=t.name,n=t.value
-return""===n&&(n=!0),r.match(/^on/i)?n=new Function(n):"style"===r&&(n=(0,m.default)(n)),r=g.default[r.toLowerCase()]||(0,d.default)(r),c({},e,o({},r,n))},{key:t})}},{key:"render",value:function(){return l.default.createElement("div",{className:"jsx-parser"},this.ParsedChildren)}}]),t}(f.Component)
-t.default=N,N.defaultProps={bindings:{},blacklistedAttrs:["on[a-z]*"],blacklistedTags:["script"],components:[],jsx:"",showWarnings:!1}
+return""===n&&(n=!0),r.match(/^on/i)?n=new Function(n):"style"===r&&(n=(0,b.default)(n)),r=E.default[r.toLowerCase()]||(0,m.default)(r),s({},e,o({},r,n))},{key:t})}},{key:"render",value:function(){return d.default.createElement("div",{className:"jsx-parser"},this.ParsedChildren)}}]),t}(p.Component)
+t.default=j,j.defaultProps={bindings:{},blacklistedAttrs:["on[a-z]*"],blacklistedTags:["script"],components:[],jsx:"",showWarnings:!1}
 r(8)},function(t,r){t.exports=e},function(e,t,r){"use strict"
 function n(e,t,r){return t in e?Object.defineProperty(e,t,{value:r,enumerable:!0,configurable:!0,writable:!0}):e[t]=r,e}function o(e){switch(void 0===e?"undefined":i(e)){case"string":return e.split(";").filter(function(e){return e}).reduce(function(e,t){var r=t.slice(0,t.indexOf(":")).trim(),o=t.slice(t.indexOf(":")+1).trim()
 return a({},e,n({},(0,c.default)(r),o))},{})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-jsx-parser",
-  "version": "0.0.13",
+  "version": "1.0.0",
   "description": "A React component which can parse JSX and output rendered React Components",
   "main": "lib/react-jsx-parser.min.js",
   "author": "Troy Alford",

--- a/source/components/JsxParser.js
+++ b/source/components/JsxParser.js
@@ -70,18 +70,13 @@ export default class JsxParser extends Component {
       return []
     }
 
-    const components = Object.entries(this.props.components).reduce((map, [key, component]) => {
-      if (isValidComponent(component)) return ({ ...map, [key]: component })
-      return map
-    }, {})
-
-    return this.parseNode(body.childNodes || [], components)
+    return this.parseNode(body.childNodes || [], this.props.components)
   }
   parseNode(node, components = {}, key) {
     if (node instanceof NodeList || Array.isArray(node)) {
       return Array.from(node) // handle nodeList or []
         .map((child, index) => this.parseNode(child, components, index))
-        .filter(child => child) // remove falsy nodes
+        .filter(Boolean) // remove falsy nodes
     }
 
     if (node.nodeType === NODE_TYPES.TEXT) {

--- a/source/components/JsxParser.js
+++ b/source/components/JsxParser.js
@@ -27,14 +27,6 @@ const warnParseErrors = (doc) => {
   errors.forEach(e => warn(e, ' '))
 }
 
-function isValidComponent(component) {
-  return (component && (
-    component.prototype instanceof React.Component ||
-    component.prototype instanceof React.PureComponent ||
-    typeof component === 'function'
-  ))
-}
-
 export default class JsxParser extends Component {
   constructor(props) {
     super(props)
@@ -166,11 +158,10 @@ if (process.env.NODE_ENV === 'production') {
   // eslint-disable-next-line global-require,import/no-extraneous-dependencies
   const PropTypes = require('prop-types')
   JsxParser.propTypes = {
-    // eslint-disable-next-line react/forbid-prop-types
-    bindings:         PropTypes.object.isRequired,
+    bindings:         PropTypes.shape({}),
     blacklistedAttrs: PropTypes.arrayOf(PropTypes.string),
     blacklistedTags:  PropTypes.arrayOf(PropTypes.string),
-    components:       PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
+    components:       PropTypes.shape({}),
     jsx:              PropTypes.string,
 
     showWarnings: PropTypes.bool,

--- a/source/components/JsxParser.test.js
+++ b/source/components/JsxParser.test.js
@@ -1,13 +1,14 @@
-import * as React from 'react'
-import * as ReactDOM from 'react-dom'
+import React, { Component } from 'react'
+import ReactDOM from 'react-dom'
 import TestUtils from 'react-dom/test-utils'
 import JsxParser from './JsxParser'
 
 jest.unmock('./JsxParser')
 
 // eslint-disable-next-line react/prefer-stateless-function
-class Custom extends React.Component {
+class Custom extends Component {
   /* eslint-disable react/prop-types */
+
   render() {
     return (
       <div className={this.props.className}>
@@ -108,7 +109,7 @@ describe('JsxParser Component', () => {
   it('renders custom components', () => {
     const { component, rendered } = render(
       <JsxParser
-        components={[Custom]}
+        components={{ Custom }}
         jsx={
           '<h1>Header</h1>' +
           '<Custom className="blah" text="Test Text" />'
@@ -136,7 +137,7 @@ describe('JsxParser Component', () => {
   it('renders custom components with nesting', () => {
     const { component, rendered } = render(
       <JsxParser
-        components={[Custom]}
+        components={{ Custom }}
         jsx={
           '<Custom className="outer" text="outerText">' +
             '<Custom className="inner" text="innerText">' +
@@ -223,7 +224,7 @@ describe('JsxParser Component', () => {
     const { component } = render(
       <JsxParser
         bindings={{ foo: 'Foo', bar: 'Bar' }}
-        components={[Custom]}
+        components={{ Custom }}
         jsx={
           '<Custom bar="Baz"></Custom>' +
           '<div foo="Fu"></div>'
@@ -387,7 +388,7 @@ describe('JsxParser Component', () => {
 
     const { rendered } = render(
       <JsxParser
-        components={[CustomContent]}
+        components={{ CustomContent }}
         jsx="<CustomContent /><p>Text</p>"
       />
     )
@@ -406,7 +407,7 @@ describe('JsxParser Component', () => {
 
     const { rendered } = render(
       <JsxParser
-        components={[CustomContent, CuStomContent]}
+        components={{ CustomContent, CuStomContent }}
         jsx="<CustomContent /><CuStomContent />"
       />
     )


### PR DESCRIPTION
Closes #13 
 - This is a breaking change, so it will require a major version number bump (1.0.0)

The previous method of declaring custom components to be available for rendering relied on the idea that each such component would have a `component.constructor.name` available. Unfortunately, most modern build processes will make this assumption untrue.

As a better API, the `components` prop is being rewritten to support a map, instead. As a result, case-sensitive comparison of the `JSX` tag name can be made directly against the keys of the map, and if a match is found, the map's associated value will be used to render.