### PR TITLE
Make it compatible with components that use onlyOne

### DIFF
--- a/lib/react-jsx-parser.min.js
+++ b/lib/react-jsx-parser.min.js
@@ -24,7 +24,7 @@ case"JSXExpressionContainer":return this.parseExpression(t.expression)
 case"Literal":return i
 default:return}}},{key:"parseElement",value:function(t,e){var s=this,i=this.props,r=i.bindings,n=void 0===r?{}:r,a=i.components,h=void 0===a?{}:a,p=t.children,c=void 0===p?[]:p,u=t.openingElement,f=u.attributes,y=u.name.name
 if(/^(html|head|body)$/i.test(y))return c.map(function(t){return s.parseElement(t)})
-if(-1===this.blacklistedTags.indexOf(y.trim().toLowerCase())){var v=void 0;(0,x.canHaveChildren)(y)&&(v=c.map(this.parseExpression),(0,x.canHaveWhitespace)(y)||(v=v.filter(function(t){return"string"!=typeof t||!/^\s*$/.test(t)})),0===v.length&&(v=void 0))
+if(-1===this.blacklistedTags.indexOf(y.trim().toLowerCase())){var v=void 0;(0,x.canHaveChildren)(y)&&(v=c.map(this.parseExpression),(0,x.canHaveWhitespace)(y)||(v=v.filter(function(t){return"string"!=typeof t||!/^\s*$/.test(t)})),0===v.length?v=void 0:1===v.length&&(v=v[0]))
 var b=o({key:e},n)
 return f.forEach(function(t){var e=t.name.name,i=m.default[e]||e,r=s.parseExpression(t)
 0===s.blacklistedAttrs.filter(function(t){return t.test(i)}).length&&(b[i]=r)}),"string"==typeof b.style&&(b.style=(0,d.default)(b.style)),l.default.createElement(h[y]||y,b,v)}}},{key:"render",value:function(){return l.default.createElement("div",{className:"jsx-parser"},this.ParsedChildren)}}]),e}(c.Component)

--- a/source/components/JsxParser.js
+++ b/source/components/JsxParser.js
@@ -96,6 +96,7 @@ export default class JsxParser extends Component {
       }
 
       if (parsedChildren.length === 0) parsedChildren = undefined
+      else if (parsedChildren.length === 1) parsedChildren = parsedChildren[0]
     }
 
     const attrs = { key, ...bindings }

--- a/source/components/JsxParser.test.js
+++ b/source/components/JsxParser.test.js
@@ -20,6 +20,19 @@ class Custom extends Component {
   }
 }
 
+// eslint-disable-next-line react/prefer-stateless-function
+class OnlyOne extends Component {
+  /* eslint-disable react/prop-types */
+
+  render() {
+    return (
+      <div>
+        {React.Children.only(this.props.children)}
+      </div>
+    )
+  }
+}
+
 describe('JsxParser Component', () => {
   let parent = null
 
@@ -148,7 +161,6 @@ describe('JsxParser Component', () => {
         }
       />
     )
-
     expect(component.ParsedChildren).toHaveLength(1)
     expect(rendered.childNodes).toHaveLength(1)
 
@@ -172,10 +184,9 @@ describe('JsxParser Component', () => {
     expect(div.nodeName).toEqual('DIV')
 
     const divChildren = Array.from(div.childNodes)
-    expect(divChildren).toHaveLength(3)
-    expect(divChildren.map(n => n.nodeType))
-      .toEqual([8, 3, 8])
-    expect(divChildren[1].textContent).toEqual('Non-Custom')
+    expect(divChildren).toHaveLength(1)
+    expect(divChildren[0].nodeType).toEqual(3)
+    expect(divChildren[0].textContent).toEqual('Non-Custom')
   })
 
   it('handles unrecognized components', () => {
@@ -195,11 +206,8 @@ describe('JsxParser Component', () => {
       />
     )
 
-    expect(component.ParsedChildren).toHaveLength(1)
     expect(component.ParsedChildren[0].props.foo).toEqual('Foo')
-    expect(component.ParsedChildren[0].props.children).toHaveLength(1)
-    expect(component.ParsedChildren[0].props.children[0].props.bar).toEqual('Bar')
-    expect(component.ParsedChildren[0].props.children[0].props.children).toHaveLength(1)
+    expect(component.ParsedChildren[0].props.children.props.bar).toEqual('Bar')
 
     expect(rendered.childNodes).toHaveLength(1)
     const outer = rendered.childNodes[0]
@@ -453,5 +461,25 @@ describe('JsxParser Component', () => {
     )
 
     expect(rendered.childNodes).toHaveLength(2)
+  })
+
+  it('renders only one children without throwing', () => {
+    expect(() => render(
+      <JsxParser
+        components={{ OnlyOne }}
+        jsx={`<OnlyOne><h1>Ipsum</h1></OnlyOne>`}
+      />
+      )
+    ).not.toThrow()
+  })
+
+  it('throws with more than one child', () => {
+    expect(() => render(
+      <JsxParser
+        components={{ OnlyOne }}
+        jsx={`<OnlyOne><h1>Ipsum</h1><h1>Ipsum</h1></OnlyOne>`}
+      />
+      )
+    ).toThrow()
   })
 })


### PR DESCRIPTION
Hi there!
Thanks for that superb component. I'm using it to build a documentation. 

**Problem:** Some of our components use the `React.Children.only()` function, to make sure only one child is passed.
The JSX parser however always passes an array, even if there is only one child. Therefore our components throw.

I changed this behaviour and fixed the tests. I changed the behaviour of the "ParsedChildren" prop, however since this is an internal variable, it should be fine.

Let me know what you think!