### PR TITLE
:bug:fix - Custom elements named after VOID or No-Whitespace elements should allow children

### DIFF
--- a/source/components/JsxParser.js
+++ b/source/components/JsxParser.js
@@ -87,16 +87,19 @@ export default class JsxParser extends Component {
 
     if (this.blacklistedTags.indexOf(name.trim().toLowerCase()) !== -1) return undefined
     let parsedChildren
-    if (canHaveChildren(name)) {
+    if (components[name] || canHaveChildren(name)) {
       parsedChildren = children.map(this.parseExpression)
-      if (!canHaveWhitespace(name)) {
+      if (!components[name] && !canHaveWhitespace(name)) {
         parsedChildren = parsedChildren.filter(child =>
           typeof child !== 'string' || !/^\s*$/.test(child)
         )
       }
 
-      if (parsedChildren.length === 0) parsedChildren = undefined
-      else if (parsedChildren.length === 1) parsedChildren = parsedChildren[0]
+      if (parsedChildren.length === 0) {
+        parsedChildren = undefined
+      } else if (parsedChildren.length === 1) {
+        parsedChildren = parsedChildren[0]
+      }
     }
 
     const attrs = { key, ...bindings }
@@ -132,6 +135,7 @@ JsxParser.defaultProps = {
   blacklistedTags:  ['script'],
   components:       [],
   jsx:              '',
+  onError:          () => {},
   showWarnings:     false,
 }
 
@@ -148,7 +152,7 @@ if (process.env.NODE_ENV !== 'production') {
     blacklistedTags: PropTypes.arrayOf(PropTypes.string),
     components:      PropTypes.shape({}),
     jsx:             PropTypes.string,
-    onError: PropTypes.func,
-    showWarnings: PropTypes.bool,
+    onError:         PropTypes.func,
+    showWarnings:    PropTypes.bool,
   }
 }

--- a/source/components/JsxParser.test.js
+++ b/source/components/JsxParser.test.js
@@ -485,11 +485,17 @@ describe('JsxParser Component', () => {
   })
 
   it('allows no-whitespace-element named custom components to take whitespace', () => {
-    const td = ({ children }) => (<div className="td">{children}</div>)
+    const tr = ({ children }) => (<div className="tr">{children}</div>)
     const { rendered } = render(
-      <JsxParser components={{ td }} jsx={'<td> Text </td>'} />
+      <JsxParser components={{ tr }} jsx={'<tr> <a href="/url">Text</a> </tr>'} />
     )
     expect(rendered.childNodes[0].nodeName).toEqual('DIV')
-    expect(rendered.childNodes[0].textContent).toEqual(' Text ')
+    expect(rendered.childNodes[0].childNodes).toHaveLength(7)
+
+    const nodeTypes = Array.from(rendered.childNodes[0].childNodes).map(cn => cn.nodeType)
+    expect(nodeTypes).toEqual([8, 3, 8, 1, 8, 3, 8])
+    expect(rendered.childNodes[0].childNodes[1].textContent).toEqual(' ')
+    expect(rendered.childNodes[0].childNodes[3].textContent).toEqual('Text')
+    expect(rendered.childNodes[0].childNodes[5].textContent).toEqual(' ')
   })
 })

--- a/source/components/JsxParser.test.js
+++ b/source/components/JsxParser.test.js
@@ -20,19 +20,6 @@ class Custom extends Component {
   }
 }
 
-// eslint-disable-next-line react/prefer-stateless-function
-class OnlyOne extends Component {
-  /* eslint-disable react/prop-types */
-
-  render() {
-    return (
-      <div>
-        {React.Children.only(this.props.children)}
-      </div>
-    )
-  }
-}
-
 describe('JsxParser Component', () => {
   let parent = null
 
@@ -463,11 +450,16 @@ describe('JsxParser Component', () => {
     expect(rendered.childNodes).toHaveLength(2)
   })
 
+
+  const OnlyOne = ({ children }) => (
+    <div>{React.Children.only(children)}</div>
+  )
+
   it('renders only one children without throwing', () => {
     expect(() => render(
       <JsxParser
         components={{ OnlyOne }}
-        jsx={`<OnlyOne><h1>Ipsum</h1></OnlyOne>`}
+        jsx={'<OnlyOne><h1>Ipsum</h1></OnlyOne>'}
       />
       )
     ).not.toThrow()
@@ -477,9 +469,27 @@ describe('JsxParser Component', () => {
     expect(() => render(
       <JsxParser
         components={{ OnlyOne }}
-        jsx={`<OnlyOne><h1>Ipsum</h1><h1>Ipsum</h1></OnlyOne>`}
+        jsx={'<OnlyOne><h1>Ipsum</h1><h1>Ipsum</h1></OnlyOne>'}
       />
       )
     ).toThrow()
+  })
+
+  it('allows void-element named custom components to take children', () => {
+    const link = ({ to, children }) => (<a href={to}>{children}</a>)
+    const { rendered } = render(
+      <JsxParser components={{ link }} jsx={'<link to="/url">Text</link>'} />
+    )
+    expect(rendered.childNodes[0].nodeName).toEqual('A')
+    expect(rendered.childNodes[0].textContent).toEqual('Text')
+  })
+
+  it('allows no-whitespace-element named custom components to take whitespace', () => {
+    const td = ({ children }) => (<div className="td">{children}</div>)
+    const { rendered } = render(
+      <JsxParser components={{ td }} jsx={'<td> Text </td>'} />
+    )
+    expect(rendered.childNodes[0].nodeName).toEqual('DIV')
+    expect(rendered.childNodes[0].textContent).toEqual(' Text ')
   })
 })


### PR DESCRIPTION
Fixes #27 
 - Custom elements whose name is the same as a VOID element (one which does not allow children, by spec) should allow them. A good example is a `<Link />` element, which should allow children, even though the HTML element `<link />` does not.
 - Custom elements whose name is the same as a no-whitespace element (such as `table` or `tr`) should allow whitespace.