### PR TITLE
Support for parsing of MemberExpressions

### DIFF
--- a/source/components/JsxParser.js
+++ b/source/components/JsxParser.js
@@ -58,6 +58,17 @@ export default class JsxParser extends Component {
     return parsed.map(this.parseExpression).filter(Boolean)
   }
 
+  getObject = (expression) => {
+    switch (expression.type) {
+      case 'MemberExpression':
+        return (this.getObject(expression.object) || {})[expression.property.name]
+      case 'Identifier':
+        return this.props.bindings[expression.name] || {}
+      default:
+        return undefined
+    }
+  }
+
   parseExpression = (expression) => {
     /* eslint-disable no-case-declarations */
     switch (expression.type) {
@@ -83,6 +94,8 @@ export default class JsxParser extends Component {
         return this.parseExpression(expression.expression)
       case 'Literal':
         return expression.value
+      case 'MemberExpression':
+        return this.getObject(expression)
 
       default:
         return undefined

--- a/source/components/JsxParser.test.js
+++ b/source/components/JsxParser.test.js
@@ -217,21 +217,28 @@ describe('JsxParser Component', () => {
           foo: 'Foo',
           bar: 'Bar',
           logFn,
+          nested: {
+            objects: {
+              work: true
+            }
+          }
         }}
         blacklistedAttrs={[]}
         components={{ Custom }}
         jsx={
           '<Custom foo={foo} bar={bar}></Custom>' +
           '<div foo={foo} />' +
-          '<span onClick={logFn}>Click Me!</span>'
+          '<span onClick={logFn}>Click Me!</span>' +
+          '<div doTheyWork={nested.objects.work} />'
         }
       />
     )
 
-    expect(component.ParsedChildren).toHaveLength(3)
+    expect(component.ParsedChildren).toHaveLength(4)
     expect(component.ParsedChildren[0].props).toEqual({ foo: 'Foo', bar: 'Bar' })
     expect(component.ParsedChildren[1].props).toEqual({ foo: 'Foo' })
     expect(component.ParsedChildren[2].props.onClick).toEqual(logFn)
+    expect(component.ParsedChildren[3].props).toEqual({ doTheyWork: true })
   })
 
   it('strips <script src="..."> tags by default', () => {


### PR DESCRIPTION
To allow the access of objects from bindings:

```javascript
<JsxParser
    bindings={{
      nested: {
        objects: {
          work: true
        }
      }
    }}
    blacklistedAttrs={[]}
    components={{  }}
    jsx={
      '<div doTheyWork={nested.objects.work} />'
    }
  />
```

(this resulted in `undefined` before)