### PR TITLE
Add unary plus/negation feature plus test coverage

### DIFF
--- a/source/components/JsxParser.js
+++ b/source/components/JsxParser.js
@@ -89,6 +89,15 @@ export default class JsxParser extends Component {
           default:
             return undefined
         }
+      case 'UnaryExpression':
+        switch (expression.operator) {
+          case '+':
+            return expression.argument.value
+          case '-':
+            return -1 * expression.argument.value
+          default:
+            return undefined
+        }
       default:
         return undefined
     }

--- a/source/components/JsxParser.js
+++ b/source/components/JsxParser.js
@@ -95,6 +95,8 @@ export default class JsxParser extends Component {
             return expression.argument.value
           case '-':
             return -1 * expression.argument.value
+          case '!':
+            return (!expression.argument.value).toString()
           default:
             return undefined
         }
@@ -167,7 +169,13 @@ export default class JsxParser extends Component {
       const value = this.parseExpression(expr)
 
       const matches = blacklistedAttrs.filter(re => re.test(attributeName))
-      if (matches.length === 0) props[attributeName] = value
+      if (matches.length === 0) {
+        if (value === 'true' || value === 'false') {
+          props[attributeName] = (value === 'true')
+        } else {
+          props[attributeName] = value
+        }
+      }
     })
 
     if (typeof props.style === 'string') {

--- a/source/components/JsxParser.test.js
+++ b/source/components/JsxParser.test.js
@@ -708,6 +708,11 @@ describe('JsxParser Component', () => {
       expect(rendered.childNodes[0].textContent).toEqual('-75')
       expect(component.ParsedChildren[0].props.testProp).toEqual(-60)
     })
+    it('can execute unary NOT operations', () => {
+      const { rendered, component } = render(<JsxParser jsx={'<span testProp={!60}>{ !false }</span>'} />)
+      expect(rendered.childNodes[0].textContent).toEqual('true')
+      expect(component.ParsedChildren[0].props.testProp).toEqual(false)
+    })
   })
   describe('React.Children.only()', () => {
     // eslint-disable-next-line react/prop-types

--- a/source/components/JsxParser.test.js
+++ b/source/components/JsxParser.test.js
@@ -698,6 +698,16 @@ describe('JsxParser Component', () => {
       const { rendered } = render(<JsxParser jsx={'<span>{ 1 + 2 * 4 / 8 }</span>'} />)
       expect(rendered.childNodes[0].textContent).toEqual('2')
     })
+    it('can execute unary plus operations', () => {
+      const { rendered, component } = render(<JsxParser jsx={'<span testProp={+60}>{ +75 }</span>'} />)
+      expect(rendered.childNodes[0].textContent).toEqual('75')
+      expect(component.ParsedChildren[0].props.testProp).toEqual(60)
+    })
+    it('can execute unary negation operations', () => {
+      const { rendered, component } = render(<JsxParser jsx={'<span testProp={-60}>{ -75 }</span>'} />)
+      expect(rendered.childNodes[0].textContent).toEqual('-75')
+      expect(component.ParsedChildren[0].props.testProp).toEqual(-60)
+    })
   })
   describe('React.Children.only()', () => {
     // eslint-disable-next-line react/prop-types


### PR DESCRIPTION
Hi, following up on Issue #72 , I am making a Pull Request for `react-jsx-parser` to support unary plus/negation.  Created unit tests, all tests pass, and ESLint passes as well.  I did not commit the `react-jsx-parser.min.js` file though as I wasn't sure about your project repo's build/sem-ver workflow.  If you could please build/deploy/bump the to the latest version after approval, that would be much appreciated.  Please kindly approve and/or let me know next steps to proceed with this PR.

Thank you.