### PR TITLE
Added support for JSX spread operator and unit test

### DIFF
--- a/source/components/JsxParser.js
+++ b/source/components/JsxParser.js
@@ -155,17 +155,32 @@ export default class JsxParser extends Component {
 
     const props = { key: randomHash() }
     attributes.forEach((expr) => {
-      const rawName = expr.name.name
-      const attributeName = ATTRIBUTES[rawName] || rawName
-      // if the value is null, this is an implicitly "true" prop, such as readOnly
-      const value = this.parseExpression(expr)
+      if(expr.type === 'JSXAttribute') {
+        const rawName = expr.name.name
+        const attributeName = ATTRIBUTES[rawName] || rawName
+        // if the value is null, this is an implicitly "true" prop, such as readOnly
+        const value = this.parseExpression(expr)
 
-      const matches = blacklistedAttrs.filter(re => re.test(attributeName))
-      if (matches.length === 0) {
-        if (value === 'true' || value === 'false') {
-          props[attributeName] = (value === 'true')
-        } else {
-          props[attributeName] = value
+        const matches = blacklistedAttrs.filter(re => re.test(attributeName))
+        if (matches.length === 0) {
+          if (value === 'true' || value === 'false') {
+            props[attributeName] = (value === 'true')
+          } else {
+            props[attributeName] = value
+          }
+        }
+      } 
+      else if(expr.type === 'JSXSpreadAttribute' && expr.argument.type === 'Identifier' || expr.argument.type === "MemberExpression") {
+        let val = this.parseExpression(expr.argument);
+        if(typeof val === "object") {
+          for(const rawName in val) {
+            const attributeName = ATTRIBUTES[rawName] || rawName;
+            const value = val[rawName];
+            const matches = blacklistedAttrs.filter(re => re.test(attributeName))
+            if (matches.length === 0) {
+              props[attributeName] = value;
+            }
+          }
         }
       }
     })

--- a/source/components/JsxParser.test.js
+++ b/source/components/JsxParser.test.js
@@ -134,6 +134,44 @@ describe('JsxParser Component', () => {
       expect(customHTML.nodeName).toEqual('DIV')
       expect(customHTML.textContent).toEqual('Test Text')
     })
+    it('renders custom components with spread operator', () => {
+      const props = {
+          className:"blah",
+          text:"First bad text"
+      };
+      const props2 = {
+        innerProps: {
+          text: "Test Text"
+        }
+      };
+      const { component, rendered } = render(
+        <JsxParser
+          components={{ Custom }}
+          bindings={{props, props2}}
+          jsx={
+            '<h1>Header</h1>' +
+            '<Custom {...props} {...props2.innerProps} {...{text:"More bad text"}} />'
+          }
+        />
+      )
+
+      expect(rendered.classList.contains('jsx-parser')).toBeTruthy()
+
+      expect(component.ParsedChildren).toHaveLength(2)
+      expect(rendered.childNodes).toHaveLength(2)
+
+      expect(rendered.childNodes[0].nodeName).toEqual('H1')
+      expect(rendered.childNodes[0].textContent).toEqual('Header')
+
+      const custom = component.ParsedChildren[1]
+      expect(custom instanceof Custom)
+      expect(custom.props.className).toEqual('blah')
+      expect(custom.props.text).toEqual('Test Text')
+
+      const customHTML = rendered.childNodes[1]
+      expect(customHTML.nodeName).toEqual('DIV')
+      expect(customHTML.textContent).toEqual('Test Text')
+    })
     it('renders custom components with nesting', () => {
       const { component, rendered } = render(
         <JsxParser


### PR DESCRIPTION
I added support for the spread operator in JSX. It is currently set up to only work with Identifier and MemberExpression values, so it shouldn't be vulnerable to any method of spreading something that has inline functions in it. Please let me know if anything else needs to be done/fixed for this to be merged.