### PR TITLE
Add equality and strict equality evaluation to expressions

### DIFF
--- a/source/components/JsxParser.js
+++ b/source/components/JsxParser.js
@@ -93,6 +93,10 @@ export default class JsxParser extends Component {
             return this.parseExpression(expression.left) * this.parseExpression(expression.right)
           case '/':
             return this.parseExpression(expression.left) / this.parseExpression(expression.right)
+          case '==':
+            return (this.parseExpression(expression.left) == this.parseExpression(expression.right)).toString()
+          case '===':
+            return (this.parseExpression(expression.left) === this.parseExpression(expression.right)).toString()
         } break
       case 'UnaryExpression':
         switch (expression.operator) {

--- a/source/components/JsxParser.test.js
+++ b/source/components/JsxParser.test.js
@@ -770,6 +770,16 @@ describe('JsxParser Component', () => {
       const { rendered } = render(<JsxParser jsx={'<span>{ 1 + 2 * 4 / 8 - 1 }</span>'} />)
       expect(rendered.childNodes[0].textContent).toEqual('1')
     })
+    it('can evaluate equality comparison', () => {
+      const { rendered, component } = render(<JsxParser jsx={'<span testProp={1 == 2}>{ 1 == "1" }</span>'} />)
+      expect(rendered.childNodes[0].textContent).toEqual('true')
+      expect(component.ParsedChildren[0].props.testProp).toEqual(false)
+    })
+    it('can evaluate strict equality comparison', () => {
+      const { rendered, component } = render(<JsxParser jsx={'<span testProp={1 === 1}>{ 1 === "1" }</span>'} />)
+      expect(rendered.childNodes[0].textContent).toEqual('false')
+      expect(component.ParsedChildren[0].props.testProp).toEqual(true)
+    })
     it('can execute unary plus operations', () => {
       const { rendered, component } = render(<JsxParser jsx={'<span testProp={+60}>{ +75 }</span>'} />)
       expect(rendered.childNodes[0].textContent).toEqual('75')


### PR DESCRIPTION
Hi,
I didn't find equality evaluation in binary expressions.
But they very helpful in case of paging and so on:

<InfoPage show={ state.page === 'INFO'  } />

Could you please add this feature to the codebase?