### PR TITLE
Add disableRandomKeys prop

### DIFF
--- a/source/components/JsxParser.js
+++ b/source/components/JsxParser.js
@@ -175,7 +175,7 @@ export default class JsxParser extends Component {
       }
     }
 
-    let props = {}
+    const props = {}
     if(!this.props.disableRandomKeys) {
       props.key = randomHash()
     }

--- a/source/components/JsxParser.js
+++ b/source/components/JsxParser.js
@@ -25,6 +25,7 @@ export default class JsxParser extends Component {
     onError:              () => { },
     showWarnings:         false,
     renderInWrapper:      true,
+    disableRandomKeys:    false
   }
 
   parseJSX = (rawJSX) => {
@@ -174,7 +175,11 @@ export default class JsxParser extends Component {
       }
     }
 
-    const props = { key: randomHash() }
+    let props = {}
+    if(!this.props.disableRandomKeys) {
+      props.key = randomHash()
+    }
+
     attributes.forEach((expr) => {
       if (expr.type === 'JSXAttribute') {
         const rawName = expr.name.name
@@ -248,5 +253,6 @@ if (process.env.NODE_ENV !== 'production') {
     onError:          PropTypes.func,
     showWarnings:     PropTypes.bool,
     renderInWrapper:  PropTypes.bool,
+    disableRandomKeys: PropTypes.bool
   }
 }

--- a/source/components/JsxParser.test.js
+++ b/source/components/JsxParser.test.js
@@ -401,6 +401,33 @@ describe('JsxParser Component', () => {
       )
       expect(wrapper.html()).toMatchSnapshot()
     })
+    it('disableRandomKeys should update child elements rather than unmount and remount them', () => {
+      const updates = jest.fn()
+      const unmounts = jest.fn()
+      const components = {
+        Custom: class Custom extends React.Component {
+          componentDidUpdate() {
+            updates()
+          }
+          componentWillUnmount() {
+            unmounts()
+          }
+          render() {
+            return 'Custom element!'
+          }
+        }
+      }
+      const wrapper = mount(
+        <JsxParser
+          components={components}
+          jsx={'<div><p>Hello</p><hr /><Custom /></div>'}
+          disableRandomKeys
+        />
+      )
+      wrapper.setProps({ someProp: true })
+      expect(updates).toHaveBeenCalled()
+      expect(unmounts).not.toHaveBeenCalled()
+    })
   })
   describe('blacklisting & whitelisting', () => {
     it('strips <script src="..."> tags by default', () => {


### PR DESCRIPTION
I have found that the issue raised in #73 has been a big one for me, causing any lifecycle methods inside the custom components passed to the parser to unmount and remount repeatedly instead of update. I also don't have control over the `key` element in the jsx content passed into the component, so I added a prop to disable the `randomHash` call during `parseElement`.