### PR TITLE
Fix ternary + equality expressions by returning boolean instead of string

### DIFF
--- a/source/components/JsxParser.js
+++ b/source/components/JsxParser.js
@@ -84,7 +84,7 @@ export default class JsxParser extends Component {
         return parsedCallee(...expression.arguments.map(this.parseExpression))
       case 'LogicalExpression':
         const left = this.parseExpression(expression.left)
-        if (expression.operator === '||' && left) return true
+        if (expression.operator === '||' && left) return left
         if ((expression.operator === '&&' && left) || (expression.operator === '||' && !left)) {
           return this.parseExpression(expression.right)
         }
@@ -101,13 +101,13 @@ export default class JsxParser extends Component {
           case '/':
             return this.parseExpression(expression.left) / this.parseExpression(expression.right)
           case '==':
-            return (this.parseExpression(expression.left) == this.parseExpression(expression.right)).toString()
+            return this.parseExpression(expression.left) == this.parseExpression(expression.right)
           case '!=':
-            return (this.parseExpression(expression.left) != this.parseExpression(expression.right)).toString()
+            return this.parseExpression(expression.left) != this.parseExpression(expression.right)
           case '===':
-            return (this.parseExpression(expression.left) === this.parseExpression(expression.right)).toString()
+            return this.parseExpression(expression.left) === this.parseExpression(expression.right)
           case '!==':
-            return (this.parseExpression(expression.left) !== this.parseExpression(expression.right)).toString()
+            return this.parseExpression(expression.left) !== this.parseExpression(expression.right)
         /* eslint-enable eqeqeq,max-len */
         } break
       case 'UnaryExpression':


### PR DESCRIPTION
- Fix test assertion to be correct, it was actually asserting the wrong textContent value of 'bar'
- Remove test for assumption that a boolean should be rendered to the screen. Real JSX does not support this either. `<div>{ 1 === 1}</div>` does not render `<div>true</div>`, it renders `<div />`. See: https://codesandbox.io/s/jsx-boolean-rendering-m06ux

This was causing a bug for me in my application, so I wanted to dive in and see what the issue was. 