### PR TITLE
Add index keys to children; fix broken test;

### DIFF
--- a/source/components/JsxParser.js
+++ b/source/components/JsxParser.js
@@ -123,7 +123,10 @@ export default class JsxParser extends Component {
         return expression.value.cooked
       case 'TemplateLiteral':
         return [...expression.expressions, ...expression.quasis]
-          .sort((a, b) => a.start > b.start)
+          .sort((a, b) => {
+            if (a.start < b.start) return -1
+            return 1
+          })
           .map(this.parseExpression)
           .join('')
       case 'UnaryExpression':
@@ -193,6 +196,9 @@ export default class JsxParser extends Component {
         children = undefined
       } else if (children.length === 1) {
         [children] = children
+      } else if (children.length > 1) {
+        // Add `key` to any child that is a react element (by checking if it has `.type`)
+        children = children.map((child, i) => (child && child.type) ? { ...child, key: i } : child)
       }
     }
 
@@ -235,9 +241,7 @@ export default class JsxParser extends Component {
       props.style = parseStyle(props.style)
     }
 
-    if (children) props.children = children
-
-    return React.createElement(component || name.toLowerCase(), props)
+    return React.createElement(component || name.toLowerCase(), props, children)
   }
 
   render = () => {


### PR DESCRIPTION
I need to turn off key generation and fragments based on my use case. I believe this is the reason I am getting this error:
![image](https://user-images.githubusercontent.com/168046/80446188-2bfad000-88e4-11ea-84e5-aec385573f04.png)

I thought about it and it seems safe to give children a key based on the index, because they are generated from childNodes which are static. So even if there is logic to hide or show an element it's still going to be a child even if it's null or undefined. I made sure to only apply a key to things that "look like" a react element (aka has a `.type` property). You think that makes sense?

Oh also, bonus, I fixed a broken template string test. It needed different sorting logic.