### PR TITLE
@types/react @types/react-dom => optionalDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "types": "dist/index.d.ts",
   "name": "react-jsx-parser",
   "repository": "TroyAlford/react-jsx-parser",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "dependencies": {
     "@types/jsdom": "^16.2.4",
     "acorn": "^8.0.4",
@@ -32,8 +32,6 @@
     "@types/acorn": "^4.0.5",
     "@types/enzyme": "^3.10.7",
     "@types/jest": "^26.0.14",
-    "@types/react": "^16.9.53",
-    "@types/react-dom": "^16.9.8",
     "@typescript-eslint/eslint-plugin": "^4.4.1",
     "@typescript-eslint/parser": "^4.4.1",
     "babel-core": "^7.0.0-bridge.0",
@@ -63,16 +61,20 @@
     "webpack-cli": "^4.0.0",
     "webpack-dev-server": "^3.11.0"
   },
+  "optionalDependencies": {
+    "@types/react": "^17.0.0",
+    "@types/react-dom": "^17.0.0"
+  },
   "peerDependencies": {
-    "@types/react": ">=16",
-    "@types/react-dom": ">=16",
     "react": ">=16",
     "react-dom": ">=16"
   },
   "resolutions": {
+		"@types/react": "^17.0.0",
+    "@types/react-dom": "^17.0.0",
     "browserslist": "^4.14.5",
     "extend": "^3.0.2",
-    "merge": "^1.2.1"
+		"merge": "^1.2.1"
   },
   "scripts": {
     "build": "yarn patch-package && yarn types && cross-env NODE_ENV=production webpack",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1872,17 +1872,17 @@
   resolved "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
-"@types/react-dom@^16.9.8":
-  version "16.9.8"
-  resolved "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.8.tgz#fe4c1e11dfc67155733dfa6aa65108b4971cb423"
-  integrity sha512-ykkPQ+5nFknnlU6lDd947WbQ6TE3NNzbQAkInC2EKY1qeYdTKp7onFusmYZb+ityzx2YviqT6BXSu+LyWWJwcA==
+"@types/react-dom@^17.0.0":
+  version "17.0.0"
+  resolved "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.0.tgz#b3b691eb956c4b3401777ee67b900cb28415d95a"
+  integrity sha512-lUqY7OlkF/RbNtD5nIq7ot8NquXrdFrjSOR6+w9a9RFQevGi1oZO1dcJbXMeONAPKtZ2UrZOEJ5UOCVsxbLk/g==
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.9.53":
-  version "16.9.53"
-  resolved "https://registry.npmjs.org/@types/react/-/react-16.9.53.tgz#40cd4f8b8d6b9528aedd1fff8fcffe7a112a3d23"
-  integrity sha512-4nW60Sd4L7+WMXH1D6jCdVftuW7j4Za6zdp6tJ33Rqv0nk1ZAmQKML9ZLD4H0dehA3FZxXR/GM8gXplf82oNGw==
+"@types/react@*", "@types/react@^17.0.0":
+  version "17.0.0"
+  resolved "https://registry.npmjs.org/@types/react/-/react-17.0.0.tgz#5af3eb7fad2807092f0046a1302b7823e27919b8"
+  integrity sha512-aj/L7RIMsRlWML3YB6KZiXB3fV2t41+5RBGYF8z+tAKU43Px8C3cYUZsDvf1/+Bm4FK21QWBrDutu8ZJ/70qOw==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"


### PR DESCRIPTION
Closes #164 by moving `@types/react` and `@types/react-dom` to `optionalDependencies` instead of `peerDependencies`, as they are not actually _required_ unless you're using TS.