### PR TITLE
fix: preserve children keys + respect disableKeyGeneration in children key generation

### DIFF
--- a/source/components/JsxParser.test.tsx
+++ b/source/components/JsxParser.test.tsx
@@ -1158,4 +1158,74 @@ describe('JsxParser Component', () => {
 		const { html } = render(<JsxParser className="foo" jsx="Text" />)
 		expect(html).toMatch('<div class="jsx-parser foo">Text</div>')
 	})
+
+	describe('children', () => {
+		test('keys are preserved if present and generated otherwise', () => {
+			const { component, rendered } = render(
+				<JsxParser
+					components={{ Custom }}
+					jsx={
+						'<Custom className="parent" text="parent">'
+						+ '<Custom className="child-1" text="child-1" key="child-1" />'
+						+ '<Custom className="child-2" text="child-2" />'
+						+ '<Custom className="child-3" text="child-3" key="child-3" />'
+						+ '</Custom>'
+					}
+				/>,
+			)
+
+			expect(rendered.classList.contains('jsx-parser')).toBeTruthy()
+
+			expect(rendered.childNodes).toHaveLength(1)
+			expect(component.ParsedChildren).toHaveLength(1)
+			
+			expect(component.ParsedChildren[0].props.className).toEqual('parent')
+			expect(component.ParsedChildren[0].props.text).toEqual('parent')
+			expect(component.ParsedChildren[0].props.children).toHaveLength(3)
+
+			expect(component.ParsedChildren[0].props.children[0].props.className).toEqual('child-1')
+			expect(component.ParsedChildren[0].props.children[0].props.text).toEqual('child-1')
+			expect(component.ParsedChildren[0].props.children[0].key).toEqual('child-1')
+
+			expect(component.ParsedChildren[0].props.children[1].props.className).toEqual('child-2')
+			expect(component.ParsedChildren[0].props.children[1].props.text).toEqual('child-2')
+			expect(component.ParsedChildren[0].props.children[1].key).toBeTruthy()
+
+			expect(component.ParsedChildren[0].props.children[2].props.className).toEqual('child-3')
+			expect(component.ParsedChildren[0].props.children[2].props.text).toEqual('child-3')
+			expect(component.ParsedChildren[0].props.children[2].key).toEqual('child-3')
+		})
+
+		test('key generation respects disableKeyGeneration', () => {
+			const { component, rendered } = render(
+				<JsxParser
+					components={{ Custom }}
+					jsx={
+						'<Custom className="parent" text="parent">'
+						+ '<Custom className="child-1" text="child-1" key="child-1" />'
+						+ '<Custom className="child-2" text="child-2" />'
+						+ '</Custom>'
+					}
+					disableKeyGeneration
+				/>,
+			)
+
+			expect(rendered.classList.contains('jsx-parser')).toBeTruthy()
+
+			expect(rendered.childNodes).toHaveLength(1)
+			expect(component.ParsedChildren).toHaveLength(1)
+			
+			expect(component.ParsedChildren[0].props.className).toEqual('parent')
+			expect(component.ParsedChildren[0].props.text).toEqual('parent')
+			expect(component.ParsedChildren[0].props.children).toHaveLength(2)
+
+			expect(component.ParsedChildren[0].props.children[0].props.className).toEqual('child-1')
+			expect(component.ParsedChildren[0].props.children[0].props.text).toEqual('child-1')
+			expect(component.ParsedChildren[0].props.children[0].key).toEqual('child-1')
+
+			expect(component.ParsedChildren[0].props.children[1].props.className).toEqual('child-2')
+			expect(component.ParsedChildren[0].props.children[1].props.text).toEqual('child-2')
+			expect(component.ParsedChildren[0].props.children[1].key).toBeFalsy()
+		})
+	})
 })

--- a/source/components/JsxParser.tsx
+++ b/source/components/JsxParser.tsx
@@ -261,8 +261,18 @@ export default class JsxParser extends React.Component<TProps> {
 			} else if (children.length === 1) {
 				[children] = children
 			} else if (children.length > 1) {
-				// Add `key` to any child that is a react element (by checking if it has `.type`)
-				children = children.map((child, key) => ((child && child.type) ? { ...child, key } : child))
+				// Add `key` to any child that is a react element (by checking if it has `.type`) if one
+				// does not already exist.
+				children = children.map(
+					(child, key) => (
+						(child && child.type) ?
+							{
+								...child,
+								...(this.props.disableKeyGeneration ? {} : { key: child.key || key })
+							} :
+							child
+					)
+				)
 			}
 		}
 

--- a/source/components/JsxParser.tsx
+++ b/source/components/JsxParser.tsx
@@ -260,19 +260,10 @@ export default class JsxParser extends React.Component<TProps> {
 				children = undefined
 			} else if (children.length === 1) {
 				[children] = children
-			} else if (children.length > 1) {
+			} else if (children.length > 1 && !this.props.disableKeyGeneration) {
 				// Add `key` to any child that is a react element (by checking if it has `.type`) if one
 				// does not already exist.
-				children = children.map(
-					(child, key) => (
-						(child && child.type) ?
-							{
-								...child,
-								...(this.props.disableKeyGeneration ? {} : { key: child.key || key })
-							} :
-							child
-					)
-				)
+				children = children.map((child, key) => ((child && child.type) ? { ...child, key: child.key || key } : child))
 			}
 		}
 


### PR DESCRIPTION
* If a `key` already exists on a given child component, use it rather than overwriting it.
* Only generate `key`s for `children` if `disableKeyGeneration` prop is `false`.

Fixes #191