### PR TITLE
Add basic support for arrow functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ const MyComponent = () => (
       <h1>Header</h1>
       <InjectableComponent eventHandler={myEventHandler} truthyProp />
       <Library.SomeComponent someProp={foo} calc={1 + 1} stringProp="foo" />
+      <Library.DataFetcher>((data) => <div>{data.name}</div>)</Library.DataFetcher>
     `}
   />
 )
@@ -46,10 +47,12 @@ Finally, a note about property bindings. The `JsxParser` can handle several type
  - string-value binding, such as `stringProp="foo"`
  - expression-binding, such as `calc={1 + 1}`
  - named-value binding, such as `eventHandler={myEventHandler}` (note that this requires a match in `bindings`)
+ - simple [single statement arrow expressions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#basic_syntax) `(item) => <p>{item.name}</p>`
 
 The component **_does not_** support inline function declarations, such as:
  - `onClick={function (event) { /* do stuff */ }}`, or
  - `onKeyPress={event => { /* do stuff */}}`
+ - Function or arrow functions with bodies `() => { return <p>This will not work</p> }`
 
 This is to prevent inadvertent XSS attack vectors. Since the primary use of this component is to allow JSX to be stored server-side, and then late-interpreted at the client-side, this restriction prevents a malicious user from stealing info by executing a situation like:
 ```javascript

--- a/source/components/JsxParser.test.tsx
+++ b/source/components/JsxParser.test.tsx
@@ -1238,4 +1238,42 @@ describe('JsxParser Component', () => {
 			expect(component.ParsedChildren[0].props.children[1].key).toBeFalsy()
 		})
 	})
+
+	it('supports arrow functions with nested jsx and implicit return', () => {
+		// https://astexplorer.net/#/gist/fc48b12b8410a4ef779e0477a644bb06/cdbfc8b929b31e11e577dceb88e3a1ee9343f68e
+		const { html } = render(
+			<JsxParser
+				components={{ Custom }}
+				bindings={{ items: [1, 2] }}
+				jsx="{items.map(item => <Custom><p>{item}</p></Custom>)}"
+			/>,
+		)
+		expect(html).toMatch('<div class="jsx-parser"><div><p>1</p></div><div><p>2</p></div></div>')
+	})
+
+	it.skip('[TODO] supports arrow functions passed objects with nested jsx and implicit return', () => {
+		// https://astexplorer.net/#/gist/fc48b12b8410a4ef779e0477a644bb06/cdbfc8b929b31e11e577dceb88e3a1ee9343f68e
+		const { html } = render(
+			<JsxParser
+				components={{ Custom}}
+				bindings={{ items: [{ name: 'bob'}] }}
+				jsx="{items.map(item => <Custom text={item.name}><p>{item.name}</p></Custom>)}"
+			/>,
+		)
+		expect(html).toMatch('<div class="jsx-parser"><div><p>bob</p></div></div>')
+	})
+
+	it.skip('[NOT IMPLEMENTED: included for PR discussion] supports function expressions with nested jsx', () => {
+		// this doesn't work because we need to support
+		// ReturnStatement + BlockStatement
+		// in order to parse the contents
+		// https://astexplorer.net/#/gist/fc48b12b8410a4ef779e0477a644bb06/89e93afa68d5b813cbb5f286d32dd86f47b57b4b
+		const { html } = render(
+			<JsxParser
+				bindings={{ items: [1, 2] }}
+				jsx="{items.map(function (item) { return <p>{item}</p> })}"
+			/>,
+		)
+		expect(html).toMatch('<div class="jsx-parser"><p>1</p><p>2</p></div>')
+	})
 })

--- a/source/components/JsxParser.test.tsx
+++ b/source/components/JsxParser.test.tsx
@@ -1240,7 +1240,9 @@ describe('JsxParser Component', () => {
 	})
 
 	it('supports arrow functions with nested jsx and implicit return', () => {
+		// see
 		// https://astexplorer.net/#/gist/fc48b12b8410a4ef779e0477a644bb06/cdbfc8b929b31e11e577dceb88e3a1ee9343f68e
+		// for acorn AST
 		const { html } = render(
 			<JsxParser
 				components={{ Custom }}
@@ -1251,16 +1253,15 @@ describe('JsxParser Component', () => {
 		expect(html).toMatch('<div class="jsx-parser"><div><p>1</p></div><div><p>2</p></div></div>')
 	})
 
-	it.skip('[TODO] supports arrow functions passed objects with nested jsx and implicit return', () => {
-		// https://astexplorer.net/#/gist/fc48b12b8410a4ef779e0477a644bb06/cdbfc8b929b31e11e577dceb88e3a1ee9343f68e
+	it('supports JSX expressions inside arrow functions', () => {
 		const { html } = render(
 			<JsxParser
-				components={{ Custom}}
-				bindings={{ items: [{ name: 'bob'}] }}
-				jsx="{items.map(item => <Custom text={item.name}><p>{item.name}</p></Custom>)}"
+				components={{ Custom }}
+				bindings={{ items: [{ name: 'Megeara', title: 'Fury' }] }}
+				jsx="{items.map(item => <Custom text={item.title}><p>{item.name}</p></Custom>)}"
 			/>,
 		)
-		expect(html).toMatch('<div class="jsx-parser"><div><p>bob</p></div></div>')
+		expect(html).toMatch('<div class="jsx-parser"><div>Fury<p>Megeara</p></div></div>')
 	})
 
 	it.skip('[NOT IMPLEMENTED: included for PR discussion] supports function expressions with nested jsx', () => {

--- a/source/components/JsxParser.test.tsx
+++ b/source/components/JsxParser.test.tsx
@@ -1239,42 +1239,75 @@ describe('JsxParser Component', () => {
 		})
 	})
 
-	it('supports arrow functions with nested jsx and implicit return', () => {
-		// see
-		// https://astexplorer.net/#/gist/fc48b12b8410a4ef779e0477a644bb06/cdbfc8b929b31e11e577dceb88e3a1ee9343f68e
-		// for acorn AST
-		const { html } = render(
-			<JsxParser
-				components={{ Custom }}
-				bindings={{ items: [1, 2] }}
-				jsx="{items.map(item => <Custom><p>{item}</p></Custom>)}"
-			/>,
-		)
-		expect(html).toMatch('<div class="jsx-parser"><div><p>1</p></div><div><p>2</p></div></div>')
-	})
+	describe('Functions', () => {
+		it('supports nested jsx inside arrow functions', () => {
+			// see
+			// https://astexplorer.net/#/gist/fc48b12b8410a4ef779e0477a644bb06/cdbfc8b929b31e11e577dceb88e3a1ee9343f68e
+			// for acorn AST
+			const { html } = render(
+				<JsxParser
+					components={{ Custom }}
+					bindings={{ items: [1, 2] }}
+					jsx="{items.map(item => <Custom><p>{item}</p></Custom>)}"
+				/>,
+			)
+			expect(html).toMatch('<div class="jsx-parser"><div><p>1</p></div><div><p>2</p></div></div>')
+		})
 
-	it('supports JSX expressions inside arrow functions', () => {
-		const { html } = render(
-			<JsxParser
-				components={{ Custom }}
-				bindings={{ items: [{ name: 'Megeara', title: 'Fury' }] }}
-				jsx="{items.map(item => <Custom text={item.title}><p>{item.name}</p></Custom>)}"
-			/>,
-		)
-		expect(html).toMatch('<div class="jsx-parser"><div>Fury<p>Megeara</p></div></div>')
-	})
+		it('supports JSX expressions inside arrow functions', () => {
+			const { html } = render(
+				<JsxParser
+					components={{ Custom }}
+					bindings={{ items: [{ name: 'Megeara', title: 'Fury' }] }}
+					jsx="{items.map(item => <Custom text={item.title}><p>{item.name}</p></Custom>)}"
+				/>,
+			)
+			expect(html).toMatch('<div class="jsx-parser"><div>Fury<p>Megeara</p></div></div>')
+		})
 
-	it.skip('[NOT IMPLEMENTED: included for PR discussion] supports function expressions with nested jsx', () => {
-		// this doesn't work because we need to support
-		// ReturnStatement + BlockStatement
-		// in order to parse the contents
-		// https://astexplorer.net/#/gist/fc48b12b8410a4ef779e0477a644bb06/89e93afa68d5b813cbb5f286d32dd86f47b57b4b
-		const { html } = render(
-			<JsxParser
-				bindings={{ items: [1, 2] }}
-				jsx="{items.map(function (item) { return <p>{item}</p> })}"
-			/>,
-		)
-		expect(html).toMatch('<div class="jsx-parser"><p>1</p><p>2</p></div>')
+		it('passes attributes', () => {
+			const PropTest = (props: { booleanAttribute: boolean}) => <>{`val:${props.booleanAttribute}`}</>
+			const { html } = render(
+				<JsxParser
+					renderInWrapper={false}
+					components={{ PropTest }}
+					bindings={{ items: [
+						{ name: 'Megeara', friend: true },
+						{ name: 'Austerious', friend: false },
+					] }}
+					jsx="{items.map(item => <p><PropTest booleanAttribute={item.friend} /></p>)}"
+				/>,
+			)
+			expect(html).toEqual('<p>val:true</p><p>val:false</p>')
+		})
+
+		it('passes spread attributes', () => {
+			const PropTest = (props: any) => <>{JSON.stringify(props)}</>
+			const { html } = render(
+				<JsxParser
+					renderInWrapper={false}
+					components={{ PropTest }}
+					bindings={{ items: [
+						{ name: 'Megeara', friend: true },
+					] }}
+					jsx="{items.map(item => <PropTest {...item} />)}"
+				/>,
+			)
+			expect(html).toEqual('{"name":"Megeara","friend":true}')
+		})
+
+		it.skip('[NOT IMPLEMENTED: included for PR discussion] supports function expressions with nested jsx', () => {
+			// this doesn't work because we need to support
+			// ReturnStatement + BlockStatement
+			// in order to parse the contents
+			// https://astexplorer.net/#/gist/fc48b12b8410a4ef779e0477a644bb06/89e93afa68d5b813cbb5f286d32dd86f47b57b4b
+			const { html } = render(
+				<JsxParser
+					bindings={{ items: [1, 2] }}
+					jsx="{items.map(function (item) { return <p>{item}</p> })}"
+				/>,
+			)
+			expect(html).toMatch('<div class="jsx-parser"><p>1</p><p>2</p></div>')
+		})
 	})
 })

--- a/source/components/JsxParser.test.tsx
+++ b/source/components/JsxParser.test.tsx
@@ -1267,7 +1267,7 @@ describe('JsxParser Component', () => {
 
 		it('passes attributes', () => {
 			const PropTest = (props: { booleanAttribute: boolean}) => <>{`val:${props.booleanAttribute}`}</>
-			const { html } = render(
+			const { html, component } = render(
 				<JsxParser
 					renderInWrapper={false}
 					components={{ PropTest }}
@@ -1279,6 +1279,9 @@ describe('JsxParser Component', () => {
 				/>,
 			)
 			expect(html).toEqual('<p>val:true</p><p>val:false</p>')
+			expect(component.ParsedChildren?.[0]).toHaveLength(2)
+			expect(component.ParsedChildren[0][0].props.children.props.booleanAttribute).toEqual(true)
+			expect(component.ParsedChildren[0][1].props.children.props.booleanAttribute).toEqual(false)
 		})
 
 		it('passes spread attributes', () => {
@@ -1296,18 +1299,17 @@ describe('JsxParser Component', () => {
 			expect(html).toEqual('{"name":"Megeara","friend":true}')
 		})
 
-		it.skip('[NOT IMPLEMENTED: included for PR discussion] supports function expressions with nested jsx', () => {
-			// this doesn't work because we need to support
-			// ReturnStatement + BlockStatement
-			// in order to parse the contents
-			// https://astexplorer.net/#/gist/fc48b12b8410a4ef779e0477a644bb06/89e93afa68d5b813cbb5f286d32dd86f47b57b4b
+		it('supports render props', () => {
+			const fakeData = { name: 'from-container'}
+			const RenderPropContainer = (props: any) => props.children(fakeData)
 			const { html } = render(
 				<JsxParser
-					bindings={{ items: [1, 2] }}
-					jsx="{items.map(function (item) { return <p>{item}</p> })}"
+					renderInWrapper={false}
+					components={{ PropTest: RenderPropContainer }}
+					jsx="{<PropTest>{(data) => <p>{data.name}</p>}</PropTest>}"
 				/>,
 			)
-			expect(html).toMatch('<div class="jsx-parser"><p>1</p><p>2</p></div>')
+			expect(html).toEqual('<p>from-container</p>')
 		})
 	})
 })

--- a/source/components/JsxParser.test.tsx
+++ b/source/components/JsxParser.test.tsx
@@ -1300,7 +1300,7 @@ describe('JsxParser Component', () => {
 		})
 
 		it('supports render props', () => {
-			const fakeData = { name: 'from-container'}
+			const fakeData = { name: 'from-container' }
 			const RenderPropContainer = (props: any) => props.children(fakeData)
 			const { html } = render(
 				<JsxParser

--- a/source/components/JsxParser.tsx
+++ b/source/components/JsxParser.tsx
@@ -298,7 +298,7 @@ export default class JsxParser extends React.Component<TProps> {
 					const rawName = expr.name.name
 					const attributeName = ATTRIBUTES[rawName] || rawName
 					// if the value is null, this is an implicitly "true" prop, such as readOnly
-					const value = this.#parseExpression(expr)
+					const value = this.#parseExpression(expr, scope)
 
 					const matches = blacklistedAttrs.filter(re => re.test(attributeName))
 					if (matches.length === 0) {

--- a/source/components/JsxParser.tsx
+++ b/source/components/JsxParser.tsx
@@ -308,7 +308,7 @@ export default class JsxParser extends React.Component<TProps> {
 					(expr.type === 'JSXSpreadAttribute' && expr.argument.type === 'Identifier')
 					|| expr.argument!.type === 'MemberExpression'
 				) {
-					const value = this.#parseExpression(expr.argument!)
+					const value = this.#parseExpression(expr.argument!, scope)
 					if (typeof value === 'object') {
 						Object.keys(value).forEach(rawName => {
 							const attributeName: string = ATTRIBUTES[rawName] || rawName

--- a/source/components/JsxParser.tsx
+++ b/source/components/JsxParser.tsx
@@ -170,7 +170,6 @@ export default class JsxParser extends React.Component<TProps> {
 			}
 			return undefined
 		case 'ArrowFunctionExpression':
-		case 'FunctionExpression':
 			if (expression.async || expression.generator) {
 				this.props.onError?.(new Error('Async and generator arrow functions are not supported.'))
 			}

--- a/source/components/JsxParser.tsx
+++ b/source/components/JsxParser.tsx
@@ -130,8 +130,8 @@ export default class JsxParser extends React.Component<TProps> {
 		case 'ExpressionStatement':
 			return this.#parseExpression(expression.expression)
 		case 'Identifier':
-			if (scope?.[expression.name]) {
-				return scope?.[expression.name]
+			if (scope && expression.name in scope) {
+				return scope[expression.name]
 			}
 			return (this.props.bindings || {})[expression.name]
 

--- a/source/types/acorn-jsx.d.ts
+++ b/source/types/acorn-jsx.d.ts
@@ -17,6 +17,22 @@ declare module 'acorn-jsx' {
 		argument?: Expression;
 	}
 
+	interface BaseFunctionExpression extends BaseExpression {
+		async: Boolean
+		generator: Boolean
+		expression: true;
+		argument?: Expression;
+		body: Expression
+		params: Identifier[]
+	}
+
+  export interface ArrowFunctionExpression extends BaseFunctionExpression {
+		type: 'ArrowFunctionExpression';
+	}
+	export interface FunctionExpression extends BaseFunctionExpression {
+		type: 'FunctionExpression';
+	}
+
 	export interface JSXFragment {
 		children: JSXElement[],
 		end: number,
@@ -148,7 +164,8 @@ declare module 'acorn-jsx' {
 		JSXSpreadAttribute | JSXFragment | JSXText |
 		ArrayExpression | BinaryExpression | CallExpression | ConditionalExpression |
 		ExpressionStatement | Identifier | Literal | LogicalExpression | MemberExpression |
-		ObjectExpression | TemplateElement | TemplateLiteral | UnaryExpression
+		ObjectExpression | TemplateElement | TemplateLiteral | UnaryExpression |
+		ArrowFunctionExpression | FunctionExpression
 
 	interface PluginOptions {
 		allowNamespacedObjects?: boolean,

--- a/source/types/acorn-jsx.d.ts
+++ b/source/types/acorn-jsx.d.ts
@@ -17,20 +17,14 @@ declare module 'acorn-jsx' {
 		argument?: Expression;
 	}
 
-	interface BaseFunctionExpression extends BaseExpression {
+  export interface ArrowFunctionExpression extends BaseExpression{
+		type: 'ArrowFunctionExpression';
 		async: Boolean
 		generator: Boolean
 		expression: true;
 		argument?: Expression;
 		body: Expression
 		params: Identifier[]
-	}
-
-  export interface ArrowFunctionExpression extends BaseFunctionExpression {
-		type: 'ArrowFunctionExpression';
-	}
-	export interface FunctionExpression extends BaseFunctionExpression {
-		type: 'FunctionExpression';
 	}
 
 	export interface JSXFragment {
@@ -165,7 +159,7 @@ declare module 'acorn-jsx' {
 		ArrayExpression | BinaryExpression | CallExpression | ConditionalExpression |
 		ExpressionStatement | Identifier | Literal | LogicalExpression | MemberExpression |
 		ObjectExpression | TemplateElement | TemplateLiteral | UnaryExpression |
-		ArrowFunctionExpression | FunctionExpression
+		ArrowFunctionExpression
 
 	interface PluginOptions {
 		allowNamespacedObjects?: boolean,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5935,7 +5935,7 @@ node-modules-regexp@^1.0.0:
   resolved "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
-node-notifier@^8.0.0, node-notifier@^8.0.1:
+node-notifier@^8.0.0:
   version "8.0.2"
   resolved "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.2.tgz#f3167a38ef0d2c8a866a83e318c1ba0efeb702c5"
   integrity sha512-oJP/9NAdd9+x2Q+rfphB2RJCHjod70RcRLjosiPMMu5gjIfwVnOUGq2nbTjTUbmy0DJ/tFIVT30+Qe3nzl4TJg==


### PR DESCRIPTION
This builds on some of the work in https://github.com/TroyAlford/react-jsx-parser/pull/114 to add support for _very_ simple arrow functions. I've wanted this to allow users to do simple templating on collections without having to layer on an additional template language inside JSX.



### Remaining questions

#### Do we need "full" function support?

I chose to parse the body of the function, rather than try to eval it. There are a few reasons for this:

1. It was relatively easy and followed the parse and return grain already laid down
2. Adding `eval`/`Function("alert('hi')")` into the mix is a little scary 🙀 

I think it might actually be fine to _not_ allow full function bodies and just support the simplified expression syntax if we wanted. I don't see this library wanting to necessarily support arbitrary JS parsing and that sort of thing is probably best left to a handler function.

I'm new to `acorn` and this library so please let me know if i've missed something obvious. 