### PR TITLE
Extend limited support for object spreading

### DIFF
--- a/source/components/JsxParser.test.tsx
+++ b/source/components/JsxParser.test.tsx
@@ -262,7 +262,7 @@ describe('JsxParser Component', () => {
 			const { component, rendered } = render(
 				<JsxParser
 					components={{ Custom }}
-					bindings={{ first, second }}
+					bindings={{ first, second, third }}
 					jsx={
 						'<Custom'
 						+ ' {...first}'

--- a/source/components/JsxParser.test.tsx
+++ b/source/components/JsxParser.test.tsx
@@ -256,6 +256,9 @@ describe('JsxParser Component', () => {
 					text: 'Test Text',
 				},
 			}
+			const third = {
+				text: 'Will Also Spread',
+			}
 			const { component, rendered } = render(
 				<JsxParser
 					components={{ Custom }}
@@ -266,6 +269,8 @@ describe('JsxParser Component', () => {
 						+ ' {...second.innerProps}'
 						+ " {...{ willNotSpread: () => { return 'Will Not Spread' } }}"
 						+ " {...{ willSpread: 'Will Spread' }}"
+						+ ' alsoWillSpread={{ ...third }}'
+						+ ' willSpreadButBeEmpty={{ ...({ maliciousFunction: () => "Will Not Spread" }) }}'
 						+ ' />'
 					}
 				/>,
@@ -280,8 +285,10 @@ describe('JsxParser Component', () => {
 			expect(custom instanceof Custom)
 			expect(custom.props.className).toEqual('blah')
 			expect(custom.props.text).toEqual('Test Text')
-			expect(custom.props.willSpread).not.toHaveProperty('Will Spread')
+			expect(custom.props.willSpread).toEqual('Will Spread')
+			expect(custom.props.alsoWillSpread.text).toEqual('Will Also Spread')
 			expect(custom.props).not.toHaveProperty('willNotSpread')
+			expect(custom.props.willSpreadButBeEmpty).not.toHaveProperty('maliciousFunction')
 
 			const customNode = rendered.childNodes[0]
 			expect(customNode.nodeName).toEqual('DIV')

--- a/source/components/JsxParser.test.tsx
+++ b/source/components/JsxParser.test.tsx
@@ -267,10 +267,10 @@ describe('JsxParser Component', () => {
 						'<Custom'
 						+ ' {...first}'
 						+ ' {...second.innerProps}'
-						+ " {...{ willNotSpread: () => { return 'Will Not Spread' } }}"
+						+ " {...{ willNotSpread: function() { return 'Will Not Spread' } }}"
 						+ " {...{ willSpread: 'Will Spread' }}"
 						+ ' alsoWillSpread={{ ...third }}'
-						+ ' willSpreadButBeEmpty={{ ...({ maliciousFunction: () => "Will Not Spread" }) }}'
+						+ ' willSpreadButBeEmpty={{ ...({ maliciousFunction: function() { return "Will Not Spread" }}) }}'
 						+ ' />'
 					}
 				/>,

--- a/source/components/JsxParser.test.tsx
+++ b/source/components/JsxParser.test.tsx
@@ -260,7 +260,14 @@ describe('JsxParser Component', () => {
 				<JsxParser
 					components={{ Custom }}
 					bindings={{ first, second }}
-					jsx="<Custom {...first} {...second.innerProps} {...{ text: 'Will Not Spread' }} />"
+					jsx={
+						'<Custom'
+						+ ' {...first}'
+						+ ' {...second.innerProps}'
+						+ " {...{ willNotSpread: () => { return 'Will Not Spread' } }}"
+						+ " {...{ willSpread: 'Will Spread' }}"
+						+ ' />'
+					}
 				/>,
 			)
 
@@ -273,13 +280,14 @@ describe('JsxParser Component', () => {
 			expect(custom instanceof Custom)
 			expect(custom.props.className).toEqual('blah')
 			expect(custom.props.text).toEqual('Test Text')
+			expect(custom.props.willSpread).not.toHaveProperty('Will Spread')
+			expect(custom.props).not.toHaveProperty('willNotSpread')
 
 			const customNode = rendered.childNodes[0]
 			expect(customNode.nodeName).toEqual('DIV')
 			expect(customNode.textContent).toEqual('Test Text')
 			const customHTML = rendered.childNodes[0].innerHTML
 			expect(customHTML).not.toMatch(/Will Be Overwritten/)
-			expect(customHTML).not.toMatch(/Will Not Spread/)
 		})
 		test('renders custom components with nesting', () => {
 			const { component, rendered } = render(

--- a/source/components/JsxParser.tsx
+++ b/source/components/JsxParser.tsx
@@ -8,6 +8,7 @@ import { randomHash } from '../helpers/hash'
 import { parseStyle } from '../helpers/parseStyle'
 import { resolvePath } from '../helpers/resolvePath'
 
+type ObjectExpression = AcornJSX.ObjectExpression
 type ParsedJSX = JSX.Element | boolean | string
 type ParsedTree = ParsedJSX | ParsedJSX[] | null
 export type TProps = {
@@ -77,7 +78,7 @@ export default class JsxParser extends React.Component<TProps> {
 		return parsed.map(p => this.#parseExpression(p)).filter(Boolean)
 	}
 
-	#sanitizeObjectExpression = (expression: AcornJSX.ObjectExpression): AcornJSX.ObjectExpression | null => {
+	#sanitizeObjectExpression = (expression: ObjectExpression): ObjectExpression | null => {
 		const sanitizedExpression = { ...expression }
 		const deniedValueTypes = ['FunctionExpression', 'ArrowFunctionExpression']
 		const filteredProps = expression.properties.filter(prop => (
@@ -168,8 +169,8 @@ export default class JsxParser extends React.Component<TProps> {
 			sanitizedExpression.properties.forEach(prop => {
 				if (prop.type === 'SpreadElement') {
 					const result = this.#parseExpression(prop.argument)
-					Object.entries(result).forEach(([key, value]) => {
-						object[key] = value
+					Object.entries(result).forEach(([propName, propValue]) => {
+						object[propName] = propValue
 					})
 				} else {
 					object[prop.key.name! || prop.key.value!] = this.#parseExpression(prop.value)

--- a/source/components/JsxParser.tsx
+++ b/source/components/JsxParser.tsx
@@ -86,7 +86,7 @@ export default class JsxParser extends React.Component<TProps> {
 
 	#sanitizeObjectExpression = (expression: ObjectExpression): ObjectExpression | null => {
 		const sanitizedExpression = { ...expression }
-		const deniedValueTypes = ['FunctionExpression', 'ArrowFunctionExpression']
+		const deniedValueTypes = ['FunctionExpression']
 		const filteredProps = expression.properties.filter(prop => (
 			prop.value == null || !deniedValueTypes.includes(prop.value.type)
 		))

--- a/source/components/JsxParser.tsx
+++ b/source/components/JsxParser.tsx
@@ -9,6 +9,8 @@ import { parseStyle } from '../helpers/parseStyle'
 import { resolvePath } from '../helpers/resolvePath'
 
 type ObjectExpression = AcornJSX.ObjectExpression
+type ObjectExpressionNode = AcornJSX.ObjectExpressionNode
+type ObjectExpressionSpreadElement = AcornJSX.ObjectExpressionSpreadElement
 type ParsedJSX = JSX.Element | boolean | string
 type ParsedTree = ParsedJSX | ParsedJSX[] | null
 export type TProps = {
@@ -30,6 +32,10 @@ export type TProps = {
 	renderUnrecognized?: (tagName: string) => JSX.Element | null,
 }
 type Scope = Record<string, any>
+
+function isSpreadElement(node: ObjectExpressionNode): node is ObjectExpressionSpreadElement {
+	return (node as ObjectExpressionSpreadElement).type === 'SpreadElement'
+}
 
 /* eslint-disable consistent-return */
 export default class JsxParser extends React.Component<TProps> {
@@ -167,7 +173,7 @@ export default class JsxParser extends React.Component<TProps> {
 				return object
 			}
 			sanitizedExpression.properties.forEach(prop => {
-				if (prop.type === 'SpreadElement') {
+				if (isSpreadElement(prop)) {
 					const result = this.#parseExpression(prop.argument)
 					Object.entries(result).forEach(([propName, propValue]) => {
 						object[propName] = propValue

--- a/source/types/acorn-jsx.d.ts
+++ b/source/types/acorn-jsx.d.ts
@@ -128,12 +128,19 @@ declare module 'acorn-jsx' {
 		raw?: string;
 	}
 
+	export interface ObjectExpressionNode {
+		key: { name?: string; value?: string },
+		value: Expression;
+	}
+
+	export interface ObjectExpressionSpreadElement extends ObjectExpressionNode {
+		type: 'SpreadElement',
+		argument: Expression;
+	}
+
 	export interface ObjectExpression extends BaseExpression {
 		type: 'ObjectExpression';
-		properties: [{
-			key: { name?: string; value?: string },
-			value: Expression;
-		}]
+		properties: ObjectExpressionNode[]
 	}
 
 	export interface TemplateElement extends BaseExpression {


### PR DESCRIPTION
Hi @TroyAlford, thanks for this library. I have a use case where I'd like to spread data objects in the jsx, e.g.:
```
  <JsxParser
    bindings={{
      thing1: { attr1: 'One' },
      thing2: { attr2: 'Two },
    }}
    components={{ MyComponent }}
    jsx={`
      <MyComponent data={{ ...thing1, ...thing2 }}>((data) => "...")</MyComponent>
    `}
  />
```

This PR updates the logic related to `ObjectExpression` and `SpreadElement` to offer limited support for additional spread functionality. I realize a change of this nature could open a can of worms, so I tried to be careful by making sure not to allow any function definitions through, but I'm new to acorn and this library so lmk if I missed anything.

For additional context on my use case, the app I'm building allows users to configure views (via `react-jsx-parser`) as well as supply data to the components via async requests (which they can also configure). The users have control over the data going into the components, but not the components available in the parser context, so I'd like to offer them more flexibility (a la spreading within `react-jsx-parser`) to allow them to shape their data according to the component contracts, and to avoid more complicated workarounds. That said, I recognize the potential risk for this change and am open to any feedback / alternatives. Thank you!