### PR TITLE
Fix: Pass scope through in binary expressions

### DIFF
--- a/source/components/JsxParser.test.tsx
+++ b/source/components/JsxParser.test.tsx
@@ -947,6 +947,25 @@ describe('JsxParser Component', () => {
 			expect(rendered.childNodes[0].textContent).toEqual('Nope')
 			expect(component.ParsedChildren[0].props.testProp).toEqual(true)
 		})
+		test('will pass along bindings in arrow function operations', () => {
+			const { component } = render(
+				<JsxParser
+					bindings={{
+						list: [1, 2, 3, 4],
+					}}
+					renderInWrapper={false}
+					jsx={
+						'<ul>'
+						+ '{list.filter(item => item % 2 === 0).map(evenItem => ('
+						+ '<li key={evenItem}>{evenItem}</li>'
+						+ '))}'
+						+ '</ul>'
+					}
+				/>,
+			)
+			expect(component.ParsedChildren).toHaveLength(1)
+			expect(component.ParsedChildren[0].props.children).toHaveLength(2)
+		})
 		test('will render options', () => {
 			window.foo = jest.fn(() => true)
 			const wrapper = mount(

--- a/source/components/JsxParser.test.tsx
+++ b/source/components/JsxParser.test.tsx
@@ -964,7 +964,7 @@ describe('JsxParser Component', () => {
 			expect(rendered.childNodes[0].textContent).toEqual('Odd')
 			expect(rendered.childNodes[1].textContent).toEqual('Even')
 			expect(rendered.childNodes[2].textContent).toEqual('Odd')
-			expect(rendered.childNodes[2].textContent).toEqual('Even')
+			expect(rendered.childNodes[3].textContent).toEqual('Even')
 		})
 		test('will pass along bindings in arrow function operations', () => {
 			const { component } = render(

--- a/source/components/JsxParser.test.tsx
+++ b/source/components/JsxParser.test.tsx
@@ -947,6 +947,24 @@ describe('JsxParser Component', () => {
 			expect(rendered.childNodes[0].textContent).toEqual('Nope')
 			expect(component.ParsedChildren[0].props.testProp).toEqual(true)
 		})
+		test('can evaluate expressions in map (nested expressions)', () => {
+			const { rendered, component } = render(
+				<JsxParser
+					renderInWrapper={false}
+					jsx={
+						'<ul>'
+						+ '{[1, 2, 3].map((item) => ('
+						+ '<li key={item}>{item % 2 === 0 ? "Even" : "Odd"}</li>'
+						+ '))}'
+						+ '</ul>'
+					}
+				/>,
+			)
+			expect(component.ParsedChildren[0].props.children).toHaveLength(3)
+			expect(rendered.childNodes[0].textContent).toEqual('Odd')
+			expect(rendered.childNodes[1].textContent).toEqual('Even')
+			expect(rendered.childNodes[2].textContent).toEqual('Odd')
+		})
 		test('will pass along bindings in arrow function operations', () => {
 			const { component } = render(
 				<JsxParser

--- a/source/components/JsxParser.test.tsx
+++ b/source/components/JsxParser.test.tsx
@@ -947,13 +947,13 @@ describe('JsxParser Component', () => {
 			expect(rendered.childNodes[0].textContent).toEqual('Nope')
 			expect(component.ParsedChildren[0].props.testProp).toEqual(true)
 		})
-		test('can evaluate expressions in map (nested expressions)', () => {
+		test('can evaluate nested expressions', () => {
 			const { rendered, component } = render(
 				<JsxParser
 					renderInWrapper={false}
 					jsx={
 						'<ul>'
-						+ '{[1, 2, 3].map((item) => ('
+						+ '{[1, 2, 3, 4].map((item) => ('
 						+ '<li key={item}>{item % 2 === 0 ? "Even" : "Odd"}</li>'
 						+ '))}'
 						+ '</ul>'
@@ -964,17 +964,15 @@ describe('JsxParser Component', () => {
 			expect(rendered.childNodes[0].textContent).toEqual('Odd')
 			expect(rendered.childNodes[1].textContent).toEqual('Even')
 			expect(rendered.childNodes[2].textContent).toEqual('Odd')
+			expect(rendered.childNodes[2].textContent).toEqual('Even')
 		})
 		test('will pass along bindings in arrow function operations', () => {
 			const { component } = render(
 				<JsxParser
-					bindings={{
-						list: [1, 2, 3, 4],
-					}}
 					renderInWrapper={false}
 					jsx={
 						'<ul>'
-						+ '{list.filter(item => item % 2 === 0).map(evenItem => ('
+						+ '{[1, 2, 3, 4].filter(item => item % 2 === 0).map(evenItem => ('
 						+ '<li key={evenItem}>{evenItem}</li>'
 						+ '))}'
 						+ '</ul>'

--- a/source/components/JsxParser.test.tsx
+++ b/source/components/JsxParser.test.tsx
@@ -960,7 +960,7 @@ describe('JsxParser Component', () => {
 					}
 				/>,
 			)
-			expect(component.ParsedChildren[0].props.children).toHaveLength(3)
+			expect(component.ParsedChildren[0].props.children).toHaveLength(4)
 			expect(rendered.childNodes[0].textContent).toEqual('Odd')
 			expect(rendered.childNodes[1].textContent).toEqual('Even')
 			expect(rendered.childNodes[2].textContent).toEqual('Odd')

--- a/source/components/JsxParser.tsx
+++ b/source/components/JsxParser.tsx
@@ -117,7 +117,7 @@ export default class JsxParser extends React.Component<TProps> {
 			}
 			return undefined
 		case 'CallExpression':
-			const parsedCallee = this.#parseExpression(expression.callee)
+			const parsedCallee = this.#parseExpression(expression.callee, scope)
 			if (parsedCallee === undefined) {
 				this.props.onError!(new Error(`The expression '${expression.callee}' could not be resolved, resulting in an undefined return value.`))
 				return undefined
@@ -126,11 +126,11 @@ export default class JsxParser extends React.Component<TProps> {
 				arg => this.#parseExpression(arg, expression.callee),
 			))
 		case 'ConditionalExpression':
-			return this.#parseExpression(expression.test)
-				? this.#parseExpression(expression.consequent)
-				: this.#parseExpression(expression.alternate)
+			return this.#parseExpression(expression.test, scope)
+				? this.#parseExpression(expression.consequent, scope)
+				: this.#parseExpression(expression.alternate, scope)
 		case 'ExpressionStatement':
-			return this.#parseExpression(expression.expression)
+			return this.#parseExpression(expression.expression, scope)
 		case 'Identifier':
 			if (scope && expression.name in scope) {
 				return scope[expression.name]
@@ -140,10 +140,10 @@ export default class JsxParser extends React.Component<TProps> {
 		case 'Literal':
 			return expression.value
 		case 'LogicalExpression':
-			const left = this.#parseExpression(expression.left)
+			const left = this.#parseExpression(expression.left, scope)
 			if (expression.operator === '||' && left) return left
 			if ((expression.operator === '&&' && left) || (expression.operator === '||' && !left)) {
-				return this.#parseExpression(expression.right)
+				return this.#parseExpression(expression.right, scope)
 			}
 			return false
 		case 'MemberExpression':
@@ -151,7 +151,7 @@ export default class JsxParser extends React.Component<TProps> {
 		case 'ObjectExpression':
 			const object: Record<string, any> = {}
 			expression.properties.forEach(prop => {
-				object[prop.key.name! || prop.key.value!] = this.#parseExpression(prop.value)
+				object[prop.key.name! || prop.key.value!] = this.#parseExpression(prop.value, scope)
 			})
 			return object
 		case 'TemplateElement':
@@ -162,7 +162,7 @@ export default class JsxParser extends React.Component<TProps> {
 					if (a.start < b.start) return -1
 					return 1
 				})
-				.map(item => this.#parseExpression(item))
+				.map(item => this.#parseExpression(item, scope))
 				.join('')
 		case 'UnaryExpression':
 			switch (expression.operator) {

--- a/source/components/JsxParser.tsx
+++ b/source/components/JsxParser.tsx
@@ -111,6 +111,8 @@ export default class JsxParser extends React.Component<TProps> {
 			case '===': return this.#parseExpression(expression.left, scope) === this.#parseExpression(expression.right, scope)
 			case '>': return this.#parseExpression(expression.left, scope) > this.#parseExpression(expression.right, scope)
 			case '>=': return this.#parseExpression(expression.left, scope) >= this.#parseExpression(expression.right, scope)
+			case '||': return this.#parseExpression(expression.left, scope) || this.#parseExpression(expression.right, scope)
+			case '&&': return this.#parseExpression(expression.left, scope) && this.#parseExpression(expression.right, scope)
 				/* eslint-enable eqeqeq,max-len */
 			}
 			return undefined

--- a/source/components/JsxParser.tsx
+++ b/source/components/JsxParser.tsx
@@ -97,20 +97,20 @@ export default class JsxParser extends React.Component<TProps> {
 		case 'BinaryExpression':
 			/* eslint-disable eqeqeq,max-len */
 			switch (expression.operator) {
-			case '-': return this.#parseExpression(expression.left) - this.#parseExpression(expression.right)
-			case '!=': return this.#parseExpression(expression.left) != this.#parseExpression(expression.right)
-			case '!==': return this.#parseExpression(expression.left) !== this.#parseExpression(expression.right)
-			case '*': return this.#parseExpression(expression.left) * this.#parseExpression(expression.right)
-			case '**': return this.#parseExpression(expression.left) ** this.#parseExpression(expression.right)
-			case '/': return this.#parseExpression(expression.left) / this.#parseExpression(expression.right)
-			case '%': return this.#parseExpression(expression.left) % this.#parseExpression(expression.right)
-			case '+': return this.#parseExpression(expression.left) + this.#parseExpression(expression.right)
-			case '<': return this.#parseExpression(expression.left) < this.#parseExpression(expression.right)
-			case '<=': return this.#parseExpression(expression.left) <= this.#parseExpression(expression.right)
-			case '==': return this.#parseExpression(expression.left) == this.#parseExpression(expression.right)
-			case '===': return this.#parseExpression(expression.left) === this.#parseExpression(expression.right)
-			case '>': return this.#parseExpression(expression.left) > this.#parseExpression(expression.right)
-			case '>=': return this.#parseExpression(expression.left) >= this.#parseExpression(expression.right)
+			case '-': return this.#parseExpression(expression.left, scope) - this.#parseExpression(expression.right, scope)
+			case '!=': return this.#parseExpression(expression.left, scope) != this.#parseExpression(expression.right, scope)
+			case '!==': return this.#parseExpression(expression.left, scope) !== this.#parseExpression(expression.right, scope)
+			case '*': return this.#parseExpression(expression.left, scope) * this.#parseExpression(expression.right, scope)
+			case '**': return this.#parseExpression(expression.left, scope) ** this.#parseExpression(expression.right, scope)
+			case '/': return this.#parseExpression(expression.left, scope) / this.#parseExpression(expression.right, scope)
+			case '%': return this.#parseExpression(expression.left, scope) % this.#parseExpression(expression.right, scope)
+			case '+': return this.#parseExpression(expression.left, scope) + this.#parseExpression(expression.right, scope)
+			case '<': return this.#parseExpression(expression.left, scope) < this.#parseExpression(expression.right, scope)
+			case '<=': return this.#parseExpression(expression.left, scope) <= this.#parseExpression(expression.right, scope)
+			case '==': return this.#parseExpression(expression.left, scope) == this.#parseExpression(expression.right, scope)
+			case '===': return this.#parseExpression(expression.left, scope) === this.#parseExpression(expression.right, scope)
+			case '>': return this.#parseExpression(expression.left, scope) > this.#parseExpression(expression.right, scope)
+			case '>=': return this.#parseExpression(expression.left, scope) >= this.#parseExpression(expression.right, scope)
 				/* eslint-enable eqeqeq,max-len */
 			}
 			return undefined

--- a/source/components/JsxParser.tsx
+++ b/source/components/JsxParser.tsx
@@ -111,8 +111,6 @@ export default class JsxParser extends React.Component<TProps> {
 			case '===': return this.#parseExpression(expression.left, scope) === this.#parseExpression(expression.right, scope)
 			case '>': return this.#parseExpression(expression.left, scope) > this.#parseExpression(expression.right, scope)
 			case '>=': return this.#parseExpression(expression.left, scope) >= this.#parseExpression(expression.right, scope)
-			case '||': return this.#parseExpression(expression.left, scope) || this.#parseExpression(expression.right, scope)
-			case '&&': return this.#parseExpression(expression.left, scope) && this.#parseExpression(expression.right, scope)
 				/* eslint-enable eqeqeq,max-len */
 			}
 			return undefined


### PR DESCRIPTION
Hi there, I noticed that list operations like `Array.filter` aren't working as expected. Here's a [Codesandbox example](https://codesandbox.io/s/react-jsx-parser-array-operations-issue-21qkfs).

The issue is that `list.filter(item => item % 2 === 0)` is returning an empty result when it should be `[2, 4]`, and the fix is simply to pass along the `scope` into the `parseExpressions` of the `BinaryExpression` case (otherwise variables like `item` aren't properly resolved).

Open to any feedback. Thanks again for this library! For context, I have [another PR](https://github.com/TroyAlford/react-jsx-parser/pull/237) open that's independent of this one.

Edit: ~~also added `||` and `&&` support to `BinaryExpression` parsing.~~ Oops, never mind, I see this is taken care of in `LogicalExpression`; will revert. I am encountering an issue but this was a red herring, will come back with another solution.

Edit II: I ended up passing `scope` into all the other `parseExpressions` that didn't already have them. The test I added illustrates a case I was running into where things weren't evaluating as expected.