### PR TITLE
fix: expressions scopes and member expressions

### DIFF
--- a/source/components/JsxParser.test.tsx
+++ b/source/components/JsxParser.test.tsx
@@ -976,6 +976,24 @@ describe('JsxParser Component', () => {
 				)
 				expect(node.innerHTML).toMatch('baz')
 			})
+			it('optional short-cut', () => {
+				const { node } = render(
+					<JsxParser
+						bindings={{ foo: { bar: { baz: 'baz' } }, foo2: undefined }}
+						jsx="{foo?.bar.baz} {foo2?.bar.baz}"
+					/>,
+				)
+				expect(node.innerHTML).toMatch('baz')
+			})
+			it('optional function call', () => {
+				const { node } = render(
+					<JsxParser
+						bindings={{ foo: { bar: () => 'baz' }, foo2: undefined }}
+						jsx="{foo?.bar()} {foo2?.bar()}"
+					/>,
+				)
+				expect(node.innerHTML).toMatch('baz')
+			})
 			/* eslint-enable dot-notation,no-useless-concat */
 		})
 	})
@@ -1284,12 +1302,12 @@ describe('JsxParser Component', () => {
 		})
 
 		it('supports math with scope', () => {
-			const { node } = render(<JsxParser jsx="[1, 2, 3].map(num => num * 2)" />)
+			const { node } = render(<JsxParser jsx="{[1, 2, 3].map(num => num * 2)}" />)
 			expect(node.innerHTML).toEqual('246')
 		})
 
 		it('supports conditional with scope', () => {
-			const { node } = render(<JsxParser jsx="[1, 2, 3].map(num == 1 || num == 3 ? num : -1)" />)
+			const { node } = render(<JsxParser jsx="{[1, 2, 3].map(num => num == 1 || num == 3 ? num : -1)}" />)
 			expect(node.innerHTML).toEqual('1-13')
 		})
 	})

--- a/source/components/JsxParser.test.tsx
+++ b/source/components/JsxParser.test.tsx
@@ -958,6 +958,24 @@ describe('JsxParser Component', () => {
 				expect(node.childNodes[0].textContent).toEqual(bindings.array[bindings.index].of)
 				expect(instance.ParsedChildren[0].props.foo).toEqual(bindings.array[bindings.index].of)
 			})
+			it('can evaluate a[b]', () => {
+				const { node } = render(
+					<JsxParser
+						bindings={{ items: { 0: 'hello', 1: 'world' }, arr: [0, 1] }}
+						jsx="{items[arr[0]]}"
+					/>,
+				)
+				expect(node.innerHTML).toMatch('hello')
+			})
+			it('handles optional chaining', () => {
+				const { node } = render(
+					<JsxParser
+						bindings={{ foo: { bar: 'baz' }, baz: undefined }}
+						jsx="{foo?.bar} {baz?.bar}"
+					/>,
+				)
+				expect(node.innerHTML).toMatch('baz')
+			})
 			/* eslint-enable dot-notation,no-useless-concat */
 		})
 	})
@@ -1263,6 +1281,16 @@ describe('JsxParser Component', () => {
 				/>,
 			)
 			expect(node.outerHTML).toEqual('<p>from-container</p>')
+		})
+
+		it('supports math with scope', () => {
+			const { node } = render(<JsxParser jsx="[1, 2, 3].map(num => num * 2)" />)
+			expect(node.innerHTML).toEqual('246')
+		})
+
+		it('supports conditional with scope', () => {
+			const { node } = render(<JsxParser jsx="[1, 2, 3].map(num == 1 || num == 3 ? num : -1)" />)
+			expect(node.innerHTML).toEqual('1-13')
 		})
 	})
 })

--- a/source/types/acorn-jsx.d.ts
+++ b/source/types/acorn-jsx.d.ts
@@ -88,6 +88,7 @@ declare module 'acorn-jsx' {
 		type: 'CallExpression';
 		arguments: Expression[];
 		callee: Expression;
+		optional: boolean;
 	}
 
 	export interface ConditionalExpression extends BaseExpression {
@@ -126,7 +127,11 @@ declare module 'acorn-jsx' {
 		name?: string;
 		object: Expression;
 		property: Expression;
-		raw?: string;
+	}
+
+	export interface ChainExpression extends BaseExpression {
+		type: 'ChainExpression';
+		expression: MemberExpression | CallExpression;
 	}
 
 	export interface ObjectExpression extends BaseExpression {
@@ -156,9 +161,9 @@ declare module 'acorn-jsx' {
 
 	export type Expression =
 		JSXAttribute | JSXAttributeExpression | JSXElement | JSXExpressionContainer |
-		JSXSpreadAttribute | JSXFragment | JSXText |
+		JSXSpreadAttribute | JSXFragment | JSXText | ChainExpression | MemberExpression |
 		ArrayExpression | BinaryExpression | CallExpression | ConditionalExpression |
-		ExpressionStatement | Identifier | Literal | LogicalExpression | MemberExpression |
+		ExpressionStatement | Identifier | Literal | LogicalExpression |
 		ObjectExpression | TemplateElement | TemplateLiteral | UnaryExpression |
 		ArrowFunctionExpression
 

--- a/source/types/acorn-jsx.d.ts
+++ b/source/types/acorn-jsx.d.ts
@@ -122,9 +122,10 @@ declare module 'acorn-jsx' {
 	export interface MemberExpression extends BaseExpression {
 		type: 'MemberExpression';
 		computed: boolean;
+		optional: boolean;
 		name?: string;
-		object: Literal | MemberExpression;
-		property?: MemberExpression;
+		object: Expression;
+		property: Expression;
 		raw?: string;
 	}
 


### PR DESCRIPTION
A few fixes, all added tests are failing on the current `develop`
I tried to simplify the `parseMemberExpression`, all tests are passing but not sure it's 100% functional