### PR TITLE
Update JsxParser.tsx

### DIFF
--- a/source/components/JsxParser.tsx
+++ b/source/components/JsxParser.tsx
@@ -131,7 +131,7 @@ export default class JsxParser extends React.Component<TProps> {
 					return undefined
 				}
 				return parsedCallee(...expression.arguments.map(
-					arg => this.#parseExpression(arg, expression.callee),
+					arg => this.#parseExpression(arg, scope),
 				))
 			case 'ConditionalExpression':
 				return this.#parseExpression(expression.test, scope)


### PR DESCRIPTION
Pass scope, not expression.callee. I ran into an issue where the scope wasn't getting passed down properly and this seemed to fix it.