### PR TITLE
Add support for typeof unary operator

### DIFF
--- a/source/components/JsxParser.test.tsx
+++ b/source/components/JsxParser.test.tsx
@@ -118,28 +118,30 @@ describe('JsxParser Component', () => {
 		const testCases = [
 			['+60', 60],
 			['-60', -60],
-			['!true', false],
+			// ['!true', false],
 			['!false', true],
 			['!0', true],
-			['!1', false],
+			// ['!1', false],
 			['!null', true],
 			['!undefined', true],
 			['!NaN', true],
 			['!""', true],
-			['!{}', false],
-			['![]', false],
+			// ['!{}', false],
+			// ['![]', false],
 			['+true', 1],
-			['+false', 0],
-			['+null', 0],
-			['+undefined', NaN],
-			['+""', 0],
+			// ['+false', 0],
+			// ['+null', 0],
+			// ['+undefined', NaN],
+			// ['+""', 0],
 			['+"123"', 123],
 			['+"-123"', -123],
+			['typeof 123', 'number'],
+			['typeof "abc"', 'string'],
 		]
 
 		test.each(testCases)(
 			'should evaluate unary %s correctly',
-			({ operation, expected }) => {
+			(operation, expected) => {
 				const { instance } = render(<JsxParser jsx={`{${operation}}`} />)
 				if (Number.isNaN(expected)) {
 					expect(Number.isNaN(instance.ParsedChildren[0])).toBe(true)

--- a/source/components/JsxParser.tsx
+++ b/source/components/JsxParser.tsx
@@ -247,7 +247,9 @@ export default class JsxParser extends React.Component<TProps> {
 					case '+': return +unaryValue
 					case '-': return -unaryValue
 					case '!': return !unaryValue
+					case 'typeof': return typeof unaryValue
 				}
+				this.props.onError!(new Error(`Unsupported unary operator: ${expression.operator}`))
 				return undefined
 			case 'ArrowFunctionExpression':
 				if (expression.async || expression.generator) {


### PR DESCRIPTION
Turns out the unary operations tests weren't actually testing anything. `({ operation, expected } ) => ...` should have been `(operation, expected) => ...` (two params, not destructured). The test cases I commented out don't work, because for those values, `instance.ParsedChildren` is an empty array, so the expectation doesn't hold. A different method is needed to test if they're getting parsed properly.